### PR TITLE
Fix missing cleanup for temporary history files

### DIFF
--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -49,7 +49,8 @@ using namespace Konsole;
 
 int Session::lastSessionId = 0;
 
-Session::Session() :
+Session::Session(QObject* parent) : 
+    QObject(parent),
         _shellProcess(0)
         , _emulation(0)
         , _monitorActivity(false)

--- a/lib/Session.h
+++ b/lib/Session.h
@@ -71,8 +71,8 @@ public:
      * falls back to using the program specified in the SHELL environment
      * variable.
      */
-    Session();
-    ~Session();
+    Session(QObject* parent = 0);
+    virtual ~Session();
 
     /**
      * Returns true if the session is currently running.  This will be true

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -48,20 +48,20 @@ struct TermWidgetImpl {
     TerminalDisplay *m_terminalDisplay;
     Session *m_session;
 
-    Session* createSession();
+    Session* createSession(QWidget* parent);
     TerminalDisplay* createTerminalDisplay(Session *session, QWidget* parent);
 };
 
 TermWidgetImpl::TermWidgetImpl(QWidget* parent)
 {
-    this->m_session = createSession();
+    this->m_session = createSession(parent);
     this->m_terminalDisplay = createTerminalDisplay(this->m_session, parent);
 }
 
 
-Session *TermWidgetImpl::createSession()
+Session *TermWidgetImpl::createSession(QWidget* parent)
 {
-    Session *session = new Session();
+    Session *session = new Session(parent);
 
     session->setTitle(Session::NameRole, "QTermWidget");
 
@@ -281,6 +281,7 @@ void QTermWidget::init(int startnow)
 
 QTermWidget::~QTermWidget()
 {
+    delete m_impl;
     emit destroyed();
 }
 

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -45,7 +45,7 @@ public:
     // A dummy constructor for Qt Designer. startnow is 1 by default
     QTermWidget(QWidget *parent = 0);
 
-    ~QTermWidget();
+    virtual ~QTermWidget();
 
     //Initial size
     QSize sizeHint() const;


### PR DESCRIPTION
QTermWidget only add the TerminalDisplay to qt's owner hierarchy for
automatic cleanup. With each new tab a new Session object will be
created and but never deleted (which would cleanup internally the
history files).

This bugfix simple adds to each Session's parent relationship the
corresponding QTermWidget.

See Issue:
https://github.com/qterminal/qterminal/issues/11
