### PR TITLE
Const-correctness for QTermWidget API.

### DIFF
--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -287,7 +287,7 @@ QTermWidget::~QTermWidget()
 }
 
 
-void QTermWidget::setTerminalFont(QFont &font)
+void QTermWidget::setTerminalFont(const QFont &font)
 {
     if (!m_impl->m_terminalDisplay)
         return;
@@ -346,7 +346,7 @@ fallback:
     return m_impl->m_session->initialWorkingDirectory();
 }
 
-void QTermWidget::setArgs(QStringList &args)
+void QTermWidget::setArgs(const QStringList &args)
 {
     if (!m_impl->m_session)
         return;

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -64,7 +64,7 @@ public:
     // Default is application font with family Monospace, size 10
     // USE ONLY FIXED-PITCH FONT!
     // otherwise symbols' position could be incorrect
-    void setTerminalFont(QFont & font);
+    void setTerminalFont(const QFont & font);
     QFont getTerminalFont();
     void setTerminalOpacity(qreal level);
 
@@ -79,7 +79,7 @@ public:
     QString workingDirectory();
 
     // Shell program args, default is none
-    void setArgs(QStringList & args);
+    void setArgs(const QStringList & args);
 
     //Text codec, default is UTF-8
     void setTextCodec(QTextCodec * codec);


### PR DESCRIPTION
`setTerminalFont()` and `setArgs()` methods of the QTermWidget class don't modify their values, thus they should take them by const reference (to support passing an unnamed temporary, for example).
