### PR TITLE
Fix python build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
 project(qtermwidget)
 
 include(GNUInstallDirs)
-include(GenerateExportHeader)
 include(CMakePackageConfigHelpers)
 include(CheckFunctionExists)
 
@@ -191,11 +190,6 @@ target_compile_definitions(${QTERMWIDGET_LIBRARY_NAME}
 )
 
 
-generate_export_header(${QTERMWIDGET_LIBRARY_NAME}
-    EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/lib/qtermwidget_export.h"
-    EXPORT_MACRO_NAME QTERMWIDGET_EXPORT
-)
-
 target_include_directories(${QTERMWIDGET_LIBRARY_NAME}
     PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lib>"
@@ -224,8 +218,7 @@ install(EXPORT
 )
 
 install(FILES
-    ${HDRS_DISTRIB} "${CMAKE_CURRENT_BINARY_DIR}/lib/qtermwidget_export.h"
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${QTERMWIDGET_LIBRARY_NAME}"
+    ${HDRS_DISTRIB} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${QTERMWIDGET_LIBRARY_NAME}"
     COMPONENT Devel
 )
 # keyboard layouts

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -24,14 +24,13 @@
 #include <QWidget>
 #include "Emulation.h"
 #include "Filter.h"
-#include "qtermwidget_export.h"
 
 class QVBoxLayout;
 struct TermWidgetImpl;
 class SearchBar;
 class QUrl;
 
-class QTERMWIDGET_EXPORT QTermWidget : public QWidget {
+class QTermWidget : public QWidget {
     Q_OBJECT
 public:
 

--- a/pyqt/qtermwidget.sip
+++ b/pyqt/qtermwidget.sip
@@ -19,12 +19,7 @@ public:
         ScrollBarRight=2
     };
 
-    enum KeyboardCursorShape
-    {
-        BlockCursor=0,
-        UnderlineCursor=1,
-        IBeamCursor=2
-    };
+    using KeyboardCursorShape = Konsole::Emulation::KeyboardCursorShape;
 
     QTermWidget(int startnow = 1, QWidget *parent = 0);
     ~QTermWidget();
@@ -66,10 +61,12 @@ public:
     void setMonitorSilence(bool);
     void setSilenceTimeout(int seconds);
     int getPtySlaveFd() const;
-    void setKeyboardCursorShape(KeyboardCursorShape shape);
     void setAutoClose(bool);
     QString title() const;
     QString icon() const;
+    void setKeyboardCursorShape(KeyboardCursorShape shape);
+    void setBlinkingCursor(bool blink);
+    void cursorChanged(Konsole::Emulation::KeyboardCursorShape cursorShape, bool blinkingCursorEnabled);
 signals:
     void finished();
     void copyAvailable(bool);


### PR DESCRIPTION
Building qtermwidget bindings for python are currently broken. It seems to have originated in b1f37a882c2d9aaa5816fbaf68eaedb38178b428 and reverting seems to have fixed it. I've also added what I _think_ are the bindings for qtermwidget.sip but they're probably wrong.

This is merely a proof of concept and should probably be tackled by someone more experienced than I. I'm willing to clean this up in any way deemed necessary though if someone wants to walk me through fixing it up.