### PR TITLE
Removes local compile definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,6 @@ target_compile_definitions(${QTERMWIDGET_LIBRARY_NAME}
         "TRANSLATIONS_DIR=\"${TRANSLATIONS_DIR}\""
         "HAVE_POSIX_OPENPT"
         "HAVE_SYS_TIME_H"
-        "QT_NO_FOREACH"
 )
 
 


### PR DESCRIPTION
QT_NO_FOREACH is already part of LXQtCompilerSettings CMake module.