### PR TITLE
Don't use automatic string conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,11 @@ target_compile_definitions(${QTERMWIDGET_LIBRARY_NAME}
         "TRANSLATIONS_DIR=\"${TRANSLATIONS_DIR}\""
         "HAVE_POSIX_OPENPT"
         "HAVE_SYS_TIME_H"
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
 )
 
 

--- a/lib/ColorScheme.cpp
+++ b/lib/ColorScheme.cpp
@@ -273,10 +273,10 @@ qreal ColorScheme::opacity() const { return _opacity; }
 void ColorScheme::read(const QString & fileName)
 {
     QSettings s(fileName, QSettings::IniFormat);
-    s.beginGroup("General");
+    s.beginGroup(QLatin1String("General"));
 
-    _description = s.value("Description", QObject::tr("Un-named Color Scheme")).toString();
-    _opacity = s.value("Opacity",qreal(1.0)).toDouble();
+    _description = s.value(QLatin1String("Description"), QObject::tr("Un-named Color Scheme")).toString();
+    _opacity = s.value(QLatin1String("Opacity"),qreal(1.0)).toDouble();
     s.endGroup();
 
     for (int i=0 ; i < TABLE_COLORS ; i++)
@@ -319,13 +319,13 @@ QString ColorScheme::colorNameForIndex(int index)
 {
     Q_ASSERT( index >= 0 && index < TABLE_COLORS );
 
-    return QString(colorNames[index]);
+    return QString::fromLatin1(colorNames[index]);
 }
 QString ColorScheme::translatedColorNameForIndex(int index)
 {
     Q_ASSERT( index >= 0 && index < TABLE_COLORS );
 
-    return translatedColorNames[index];
+    return QString::fromLatin1(translatedColorNames[index]);
 }
 
 void ColorScheme::readColorEntry(QSettings * s , int index)
@@ -336,7 +336,7 @@ void ColorScheme::readColorEntry(QSettings * s , int index)
 
     ColorEntry entry;
 
-    QVariant colorValue = s->value("Color");
+    QVariant colorValue = s->value(QLatin1String("Color"));
     QString colorStr;
     int r, g, b;
     bool ok = false;
@@ -345,7 +345,7 @@ void ColorScheme::readColorEntry(QSettings * s , int index)
     if (colorValue.type() == QVariant::StringList)
     {
         QStringList rgbList = colorValue.toStringList();
-        colorStr = rgbList.join(",");
+        colorStr = rgbList.join(QLatin1Char(','));
         if (rgbList.count() == 3)
         {
             bool parse_ok;
@@ -362,7 +362,7 @@ void ColorScheme::readColorEntry(QSettings * s , int index)
     else
     {
         colorStr = colorValue.toString();
-        QRegularExpression hexColorPattern("^#[0-9a-f]{6}$",
+        QRegularExpression hexColorPattern(QLatin1String("^#[0-9a-f]{6}$"),
                                            QRegularExpression::CaseInsensitiveOption);
         if (hexColorPattern.match(colorStr).hasMatch())
         {
@@ -381,20 +381,20 @@ void ColorScheme::readColorEntry(QSettings * s , int index)
     }
     entry.color = QColor(r, g, b);
 
-    entry.transparent = s->value("Transparent",false).toBool();
+    entry.transparent = s->value(QLatin1String("Transparent"),false).toBool();
 
     // Deprecated key from KDE 4.0 which set 'Bold' to true to force
     // a color to be bold or false to use the current format
     //
     // TODO - Add a new tri-state key which allows for bold, normal or
     // current format
-    if (s->contains("Bold"))
-        entry.fontWeight = s->value("Bold",false).toBool() ? ColorEntry::Bold :
+    if (s->contains(QLatin1String("Bold")))
+        entry.fontWeight = s->value(QLatin1String("Bold"),false).toBool() ? ColorEntry::Bold :
                                                                  ColorEntry::UseCurrentFormat;
 
-    quint16 hue = s->value("MaxRandomHue",0).toInt();
-    quint8 value = s->value("MaxRandomValue",0).toInt();
-    quint8 saturation = s->value("MaxRandomSaturation",0).toInt();
+    quint16 hue = s->value(QLatin1String("MaxRandomHue"),0).toInt();
+    quint8 value = s->value(QLatin1String("MaxRandomValue"),0).toInt();
+    quint8 saturation = s->value(QLatin1String("MaxRandomSaturation"),0).toInt();
 
     setColorTableEntry( index , entry );
 
@@ -502,10 +502,10 @@ ColorScheme* KDE3ColorSchemeReader::read()
 
     ColorScheme* scheme = new ColorScheme();
 
-    QRegExp comment("#.*$");
+    QRegExp comment(QLatin1String("#.*$"));
     while ( !_device->atEnd() )
     {
-        QString line(_device->readLine());
+        QString line(QString::fromUtf8(_device->readLine()));
         line.remove(comment);
         line = line.simplified();
 
@@ -533,11 +533,11 @@ ColorScheme* KDE3ColorSchemeReader::read()
 }
 bool KDE3ColorSchemeReader::readColorLine(const QString& line,ColorScheme* scheme)
 {
-    QStringList list = line.split(QChar(' '));
+    QStringList list = line.split(QLatin1Char(' '));
 
     if (list.count() != 7)
         return false;
-    if (list.first() != "color")
+    if (list.first() != QLatin1String("color"))
         return false;
 
     int index = list[1].toInt();
@@ -570,13 +570,13 @@ bool KDE3ColorSchemeReader::readTitleLine(const QString& line,ColorScheme* schem
     if( !line.startsWith(QLatin1String("title")) )
         return false;
 
-    int spacePos = line.indexOf(' ');
+    int spacePos = line.indexOf(QLatin1Char(' '));
     if( spacePos == -1 )
         return false;
 
     QString description = line.mid(spacePos+1);
 
-    scheme->setDescription(description.toUtf8());
+    scheme->setDescription(description);
     return true;
 }
 ColorSchemeManager::ColorSchemeManager()
@@ -728,11 +728,11 @@ QList<QString> ColorSchemeManager::listKDE3ColorSchemes()
         const QString dname(scheme_dir);
         QDir dir(dname);
         QStringList filters;
-        filters << "*.schema";
+        filters << QLatin1String("*.schema");
         dir.setNameFilters(filters);
         QStringList list = dir.entryList(filters);
         for (const QString &i : list)
-            ret << dname + "/" + i;
+            ret << dname + QLatin1Char('/') + i;
     }
     return ret;
     //return KGlobal::dirs()->findAllResources("data",
@@ -748,11 +748,11 @@ QList<QString> ColorSchemeManager::listColorSchemes()
         const QString dname(scheme_dir);
         QDir dir(dname);
         QStringList filters;
-        filters << "*.colorscheme";
+        filters << QLatin1String("*.colorscheme");
         dir.setNameFilters(filters);
         QStringList list = dir.entryList(filters);
         for (const QString &i : list)
-            ret << dname + "/" + i;
+            ret << dname + QLatin1Char('/') + i;
     }
     return ret;
 //    return KGlobal::dirs()->findAllResources("data",
@@ -789,12 +789,12 @@ QString ColorSchemeManager::findColorSchemePath(const QString& name) const
         return QString();
 
     const QString dir = dirs.first();
-    QString path(dir + "/"+ name + ".colorscheme");
+    QString path(dir + QLatin1Char('/')+ name + QLatin1String(".colorscheme"));
     if ( !path.isEmpty() )
         return path;
 
     //path = KStandardDirs::locate("data","konsole/"+name+".schema");
-    path = dir + "/"+ name + ".schema";
+    path = dir + QLatin1Char('/')+ name + QLatin1String(".schema");
 
     return path;
 }

--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -73,7 +73,7 @@ Emulation::Emulation() :
            SLOT(bracketedPasteModeChanged(bool)));
 
   connect(this, &Emulation::cursorChanged, [this] (KeyboardCursorShape cursorShape, bool blinkingCursorEnabled) {
-    emit titleChanged( 50, QString("CursorShape=%1;BlinkingCursorEnabled=%2")
+    emit titleChanged( 50, QString(QLatin1String("CursorShape=%1;BlinkingCursorEnabled=%2"))
                                .arg(static_cast<int>(cursorShape)).arg(blinkingCursorEnabled) );
   });
 }
@@ -214,7 +214,7 @@ void Emulation::sendKeyEvent( QKeyEvent* ev )
   { // A block of text
     // Note that the text is proper unicode.
     // We should do a conversion here
-    emit sendData(ev->text().toUtf8(),ev->text().length());
+    emit sendData(ev->text().toUtf8().constData(),ev->text().length());
   }
 }
 

--- a/lib/Filter.cpp
+++ b/lib/Filter.cpp
@@ -175,7 +175,7 @@ void TerminalImageFilterChain::setImage(const Character* const image , int lines
         // terminal image to avoid adding this imaginary character for wrapped
         // lines
         if ( !(lineProperties.value(i,LINE_DEFAULT) & LINE_WRAPPED) )
-            lineStream << QChar('\n');
+            lineStream << QLatin1Char('\n');
     }
     decoder.end();
 }
@@ -374,7 +374,7 @@ void RegExpFilter::process()
 
     // ignore any regular expressions which match an empty string.
     // otherwise the while loop below will run indefinitely
-    static const QString emptyString("");
+    static const QString emptyString;
     if ( _searchText.exactMatch(emptyString) )
         return;
 
@@ -446,29 +446,29 @@ void UrlFilter::HotSpot::activate(const QString& actionName)
 
     const UrlType kind = urlType();
 
-    if ( actionName == "copy-action" )
+    if ( actionName == QLatin1String("copy-action") )
     {
         QApplication::clipboard()->setText(url);
         return;
     }
 
-    if ( actionName.isEmpty() || actionName == "open-action" || actionName == "click-action" )
+    if ( actionName.isEmpty() || actionName == QLatin1String("open-action") || actionName == QLatin1String("click-action") )
     {
         if ( kind == StandardUrl )
         {
             // if the URL path does not include the protocol ( eg. "www.kde.org" ) then
             // prepend http:// ( eg. "www.kde.org" --> "http://www.kde.org" )
-            if (!url.contains("://"))
+            if (!url.contains(QLatin1String("://")))
             {
-                url.prepend("http://");
+                url.prepend(QLatin1String("http://"));
             }
         }
         else if ( kind == Email )
         {
-            url.prepend("mailto:");
+            url.prepend(QLatin1String("mailto:"));
         }
 
-        _urlObject->emitActivated(url, actionName != "click-action");
+        _urlObject->emitActivated(QUrl(url, QUrl::StrictMode), actionName != QLatin1String("click-action"));
     }
 }
 
@@ -480,14 +480,14 @@ void UrlFilter::HotSpot::activate(const QString& actionName)
 //regexp matches:
 // full url:
 // protocolname:// or www. followed by anything other than whitespaces, <, >, ' or ", and ends before whitespaces, <, >, ', ", ], !, comma and dot
-const QRegExp UrlFilter::FullUrlRegExp("(www\\.(?!\\.)|[a-z][a-z0-9+.-]*://)[^\\s<>'\"]+[^!,\\.\\s<>'\"\\]]");
+const QRegExp UrlFilter::FullUrlRegExp(QLatin1String("(www\\.(?!\\.)|[a-z][a-z0-9+.-]*://)[^\\s<>'\"]+[^!,\\.\\s<>'\"\\]]"));
 // email address:
 // [word chars, dots or dashes]@[word chars, dots or dashes].[word chars]
-const QRegExp UrlFilter::EmailAddressRegExp("\\b(\\w|\\.|-)+@(\\w|\\.|-)+\\.\\w+\\b");
+const QRegExp UrlFilter::EmailAddressRegExp(QLatin1String("\\b(\\w|\\.|-)+@(\\w|\\.|-)+\\.\\w+\\b"));
 
 // matches full url or email address
-const QRegExp UrlFilter::CompleteUrlRegExp('('+FullUrlRegExp.pattern()+'|'+
-                                            EmailAddressRegExp.pattern()+')');
+const QRegExp UrlFilter::CompleteUrlRegExp(QLatin1Char('(')+FullUrlRegExp.pattern()+QLatin1Char('|')+
+                                            EmailAddressRegExp.pattern()+QLatin1Char(')'));
 
 UrlFilter::UrlFilter()
 {

--- a/lib/KeyboardTranslator.cpp
+++ b/lib/KeyboardTranslator.cpp
@@ -60,7 +60,7 @@ KeyboardTranslatorManager::~KeyboardTranslatorManager()
 }
 QString KeyboardTranslatorManager::findTranslatorPath(const QString& name)
 {
-    return QString(get_kb_layout_dir() + name + ".keytab");
+    return QString(get_kb_layout_dir() + name + QLatin1String(".keytab"));
     //return KGlobal::dirs()->findResource("data","konsole/"+name+".keytab");
 }
 
@@ -68,7 +68,7 @@ void KeyboardTranslatorManager::findTranslators()
 {
     QDir dir(get_kb_layout_dir());
     QStringList filters;
-    filters << "*.keytab";
+    filters << QLatin1String("*.keytab");
     dir.setNameFilters(filters);
     QStringList list = dir.entryList(filters);
     list = dir.entryList(filters);
@@ -158,13 +158,13 @@ const KeyboardTranslator* KeyboardTranslatorManager::defaultTranslator()
 {
     // Try to find the default.keytab file if it exists, otherwise
     // fall back to the hard-coded one
-    const KeyboardTranslator* translator = findTranslator("default");
+    const KeyboardTranslator* translator = findTranslator(QLatin1String("default"));
     if (!translator)
     {
         QBuffer textBuffer;
         textBuffer.setData(defaultTranslatorText);
         textBuffer.open(QIODevice::ReadOnly);
-        translator = loadTranslator(&textBuffer,"fallback");
+        translator = loadTranslator(&textBuffer,QLatin1String("fallback"));
     }
     return translator;
 }
@@ -211,9 +211,9 @@ void KeyboardTranslatorWriter::writeEntry( const KeyboardTranslator::Entry& entr
     if ( entry.command() != KeyboardTranslator::NoCommand )
         result = entry.resultToString();
     else
-        result = '\"' + entry.resultToString() + '\"';
+        result = QLatin1Char('\"') + entry.resultToString() + QLatin1Char('\"');
 
-    *_writer << "key " << entry.conditionToString() << " : " << result << '\n';
+    *_writer << QLatin1String("key ") << entry.conditionToString() << QLatin1String(" : ") << result << QLatin1Char('\n');
 }
 
 
@@ -243,9 +243,9 @@ KeyboardTranslatorReader::KeyboardTranslatorReader( QIODevice* source )
    // read input until we find the description
    while ( _description.isEmpty() && !source->atEnd() )
    {
-        QList<Token> tokens = tokenize( QString(source->readLine()) );
+        QList<Token> tokens = tokenize( QString::fromUtf8(source->readLine()) );
         if ( !tokens.isEmpty() && tokens.first().type == Token::TitleKeyword )
-            _description = tokens[1].text.toUtf8();
+            _description = tokens[1].text;
    }
    // read first entry (if any)
    readNext();
@@ -255,7 +255,7 @@ void KeyboardTranslatorReader::readNext()
     // find next entry
     while ( !_source->atEnd() )
     {
-        const QList<Token>& tokens = tokenize( QString(_source->readLine()) );
+        const QList<Token>& tokens = tokenize( QString::fromUtf8(_source->readLine()) );
         if ( !tokens.isEmpty() && tokens.first().type == Token::KeyKeyword )
         {
             KeyboardTranslator::States flags = KeyboardTranslator::NoState;
@@ -309,21 +309,21 @@ void KeyboardTranslatorReader::readNext()
 
 bool KeyboardTranslatorReader::parseAsCommand(const QString& text,KeyboardTranslator::Command& command)
 {
-    if ( text.compare("erase",Qt::CaseInsensitive) == 0 )
+    if ( text.compare(QLatin1String("erase"),Qt::CaseInsensitive) == 0 )
         command = KeyboardTranslator::EraseCommand;
-    else if ( text.compare("scrollpageup",Qt::CaseInsensitive) == 0 )
+    else if ( text.compare(QLatin1String("scrollpageup"),Qt::CaseInsensitive) == 0 )
         command = KeyboardTranslator::ScrollPageUpCommand;
-    else if ( text.compare("scrollpagedown",Qt::CaseInsensitive) == 0 )
+    else if ( text.compare(QLatin1String("scrollpagedown"),Qt::CaseInsensitive) == 0 )
         command = KeyboardTranslator::ScrollPageDownCommand;
-    else if ( text.compare("scrolllineup",Qt::CaseInsensitive) == 0 )
+    else if ( text.compare(QLatin1String("scrolllineup"),Qt::CaseInsensitive) == 0 )
         command = KeyboardTranslator::ScrollLineUpCommand;
-    else if ( text.compare("scrolllinedown",Qt::CaseInsensitive) == 0 )
+    else if ( text.compare(QLatin1String("scrolllinedown"),Qt::CaseInsensitive) == 0 )
         command = KeyboardTranslator::ScrollLineDownCommand;
-    else if ( text.compare("scrolllock",Qt::CaseInsensitive) == 0 )
+    else if ( text.compare(QLatin1String("scrolllock"),Qt::CaseInsensitive) == 0 )
         command = KeyboardTranslator::ScrollLockCommand;
-    else if ( text.compare("scrolluptotop",Qt::CaseInsensitive) == 0)
+    else if ( text.compare(QLatin1String("scrolluptotop"),Qt::CaseInsensitive) == 0)
         command = KeyboardTranslator::ScrollUpToTopCommand;
-    else if ( text.compare("scrolldowntobottom",Qt::CaseInsensitive) == 0)
+    else if ( text.compare(QLatin1String("scrolldowntobottom"),Qt::CaseInsensitive) == 0)
         command = KeyboardTranslator::ScrollDownToBottomCommand;
     else
         return false;
@@ -392,9 +392,9 @@ bool KeyboardTranslatorReader::decodeSequence(const QString& text,
 
         // check if this is a wanted / not-wanted flag and update the
         // state ready for the next item
-        if ( ch == '+' )
+        if ( ch == QLatin1Char('+') )
            isWanted = true;
-        else if ( ch == '-' )
+        else if ( ch == QLatin1Char('-') )
            isWanted = false;
     }
 
@@ -408,15 +408,15 @@ bool KeyboardTranslatorReader::decodeSequence(const QString& text,
 
 bool KeyboardTranslatorReader::parseAsModifier(const QString& item , Qt::KeyboardModifier& modifier)
 {
-    if ( item == "shift" )
+    if ( item == QLatin1String("shift") )
         modifier = Qt::ShiftModifier;
-    else if ( item == "ctrl" || item == "control" )
+    else if ( item == QLatin1String("ctrl") || item == QLatin1String("control") )
         modifier = Qt::ControlModifier;
-    else if ( item == "alt" )
+    else if ( item == QLatin1String("alt") )
         modifier = Qt::AltModifier;
-    else if ( item == "meta" )
+    else if ( item == QLatin1String("meta") )
         modifier = Qt::MetaModifier;
-    else if ( item == "keypad" )
+    else if ( item == QLatin1String("keypad") )
         modifier = Qt::KeypadModifier;
     else
         return false;
@@ -425,17 +425,17 @@ bool KeyboardTranslatorReader::parseAsModifier(const QString& item , Qt::Keyboar
 }
 bool KeyboardTranslatorReader::parseAsStateFlag(const QString& item , KeyboardTranslator::State& flag)
 {
-    if ( item == "appcukeys" || item == "appcursorkeys" )
+    if ( item == QLatin1String("appcukeys") || item == QLatin1String("appcursorkeys") )
         flag = KeyboardTranslator::CursorKeysState;
-    else if ( item == "ansi" )
+    else if ( item == QLatin1String("ansi") )
         flag = KeyboardTranslator::AnsiState;
-    else if ( item == "newline" )
+    else if ( item == QLatin1String("newline") )
         flag = KeyboardTranslator::NewLineState;
-    else if ( item == "appscreen" )
+    else if ( item == QLatin1String("appscreen") )
         flag = KeyboardTranslator::AlternateScreenState;
-    else if ( item == "anymod" || item == "anymodifier" )
+    else if ( item == QLatin1String("anymod") || item == QLatin1String("anymodifier") )
         flag = KeyboardTranslator::AnyModifierState;
-    else if ( item == "appkeypad" )
+    else if ( item == QLatin1String("appkeypad") )
         flag = KeyboardTranslator::ApplicationKeypadState;
     else
         return false;
@@ -455,9 +455,9 @@ bool KeyboardTranslatorReader::parseAsKeyCode(const QString& item , int& keyCode
         }
     }
     // additional cases implemented for backwards compatibility with KDE 3
-    else if ( item == "prior" )
+    else if ( item == QLatin1String("prior") )
         keyCode = Qt::Key_PageUp;
-    else if ( item == "next" )
+    else if ( item == QLatin1String("next") )
         keyCode = Qt::Key_PageDown;
     else
         return false;
@@ -476,9 +476,9 @@ bool KeyboardTranslatorReader::hasNextEntry()
 KeyboardTranslator::Entry KeyboardTranslatorReader::createEntry( const QString& condition ,
                                                                  const QString& result )
 {
-    QString entryString("keyboard \"temporary\"\nkey ");
+    QString entryString = QString::fromLatin1("keyboard \"temporary\"\nkey ");
     entryString.append(condition);
-    entryString.append(" : ");
+    entryString.append(QLatin1String(" : "));
 
     // if 'result' is the name of a command then the entry result will be that command,
     // otherwise the result will be treated as a string to echo when the key sequence
@@ -487,7 +487,7 @@ KeyboardTranslator::Entry KeyboardTranslatorReader::createEntry( const QString& 
     if (parseAsCommand(result,command))
         entryString.append(result);
     else
-        entryString.append('\"' + result + '\"');
+        entryString.append(QLatin1Char('\"') + result + QLatin1Char('\"'));
 
     QByteArray array = entryString.toUtf8();
     QBuffer buffer(&array);
@@ -522,9 +522,9 @@ QList<KeyboardTranslatorReader::Token> KeyboardTranslatorReader::tokenize(const 
     for (int i=text.length()-1;i>=0;i--)
     {
         QChar ch = text[i];
-        if (ch == '\"')
+        if (ch == QLatin1Char('\"'))
             inQuotes = !inQuotes;
-        else if (ch == '#' && !inQuotes)
+        else if (ch == QLatin1Char('#') && !inQuotes)
             commentPos = i;
     }
     if (commentPos != -1)
@@ -533,10 +533,10 @@ QList<KeyboardTranslatorReader::Token> KeyboardTranslatorReader::tokenize(const 
     text = text.simplified();
 
     // title line: keyboard "title"
-    static QRegExp title("keyboard\\s+\"(.*)\"");
+    static QRegExp title(QLatin1String("keyboard\\s+\"(.*)\""));
     // key line: key KeySequence : "output"
     // key line: key KeySequence : command
-    static QRegExp key("key\\s+([\\w\\+\\s\\-\\*\\.]+)\\s*:\\s*(\"(.*)\"|\\w+)");
+    static QRegExp key(QLatin1String("key\\s+([\\w\\+\\s\\-\\*\\.]+)\\s*:\\s*(\"(.*)\"|\\w+)"));
 
     QList<Token> list;
     if ( text.isEmpty() )
@@ -554,7 +554,7 @@ QList<KeyboardTranslatorReader::Token> KeyboardTranslatorReader::tokenize(const 
     else if  ( key.exactMatch(text) )
     {
         Token keyToken = { Token::KeyKeyword , QString() };
-        Token sequenceToken = { Token::KeySequence , key.capturedTexts().value(1).remove(' ') };
+        Token sequenceToken = { Token::KeySequence , key.capturedTexts().value(1).remove(QLatin1Char(' ')) };
 
         list << keyToken << sequenceToken;
 
@@ -659,7 +659,7 @@ QByteArray KeyboardTranslator::Entry::escapedText(bool expandWildCards,Qt::Keybo
             default:
                 // any character which is not printable is replaced by an equivalent
                 // \xhh escape sequence (where 'hh' are the corresponding hex digits)
-                if ( !QChar(ch).isPrint() )
+                if ( !QChar(QLatin1Char(ch)).isPrint() )
                     replacement = 'x';
         }
 
@@ -735,20 +735,20 @@ void KeyboardTranslator::Entry::insertModifier( QString& item , int modifier ) c
         return;
 
     if ( modifier & _modifiers )
-        item += '+';
+        item += QLatin1Char('+');
     else
-        item += '-';
+        item += QLatin1Char('-');
 
     if ( modifier == Qt::ShiftModifier )
-        item += "Shift";
+        item += QLatin1String("Shift");
     else if ( modifier == Qt::ControlModifier )
-        item += "Ctrl";
+        item += QLatin1String("Ctrl");
     else if ( modifier == Qt::AltModifier )
-        item += "Alt";
+        item += QLatin1String("Alt");
     else if ( modifier == Qt::MetaModifier )
-        item += "Meta";
+        item += QLatin1String("Meta");
     else if ( modifier == Qt::KeypadModifier )
-        item += "KeyPad";
+        item += QLatin1String("KeyPad");
 }
 void KeyboardTranslator::Entry::insertState( QString& item , int state ) const
 {
@@ -756,43 +756,43 @@ void KeyboardTranslator::Entry::insertState( QString& item , int state ) const
         return;
 
     if ( state & _state )
-        item += '+' ;
+        item += QLatin1Char('+') ;
     else
-        item += '-' ;
+        item += QLatin1Char('-') ;
 
     if ( state == KeyboardTranslator::AlternateScreenState )
-        item += "AppScreen";
+        item += QLatin1String("AppScreen");
     else if ( state == KeyboardTranslator::NewLineState )
-        item += "NewLine";
+        item += QLatin1String("NewLine");
     else if ( state == KeyboardTranslator::AnsiState )
-        item += "Ansi";
+        item += QLatin1String("Ansi");
     else if ( state == KeyboardTranslator::CursorKeysState )
-        item += "AppCursorKeys";
+        item += QLatin1String("AppCursorKeys");
     else if ( state == KeyboardTranslator::AnyModifierState )
-        item += "AnyModifier";
+        item += QLatin1String("AnyModifier");
     else if ( state == KeyboardTranslator::ApplicationKeypadState )
-        item += "AppKeypad";
+        item += QLatin1String("AppKeypad");
 }
 QString KeyboardTranslator::Entry::resultToString(bool expandWildCards,Qt::KeyboardModifiers modifiers) const
 {
     if ( !_text.isEmpty() )
-        return escapedText(expandWildCards,modifiers);
+        return QString::fromLatin1(escapedText(expandWildCards,modifiers));
     else if ( _command == EraseCommand )
-        return "Erase";
+        return QLatin1String("Erase");
     else if ( _command == ScrollPageUpCommand )
-        return "ScrollPageUp";
+        return QLatin1String("ScrollPageUp");
     else if ( _command == ScrollPageDownCommand )
-        return "ScrollPageDown";
+        return QLatin1String("ScrollPageDown");
     else if ( _command == ScrollLineUpCommand )
-        return "ScrollLineUp";
+        return QLatin1String("ScrollLineUp");
     else if ( _command == ScrollLineDownCommand )
-        return "ScrollLineDown";
+        return QLatin1String("ScrollLineDown");
     else if ( _command == ScrollLockCommand )
-        return "ScrollLock";
+        return QLatin1String("ScrollLock");
     else if (_command == ScrollUpToTopCommand)
-        return "ScrollUpToTop";
+        return QLatin1String("ScrollUpToTop");
     else if (_command == ScrollDownToBottomCommand)
-        return "ScrollDownToBottom";
+        return QLatin1String("ScrollDownToBottom");
 
     return QString();
 }

--- a/lib/Pty.cpp
+++ b/lib/Pty.cpp
@@ -141,7 +141,7 @@ void Pty::addEnvironmentVariables(const QStringList& environment)
         QString pair = iter.next();
 
         // split on the first '=' character
-        int pos = pair.indexOf('=');
+        int pos = pair.indexOf(QLatin1Char('='));
 
         if ( pos >= 0 )
         {
@@ -168,11 +168,11 @@ int Pty::start(const QString& program,
   // name of the program to execute, so create a list consisting of all
   // but the first argument to pass to setProgram()
   Q_ASSERT(programArguments.count() >= 1);
-  setProgram(program.toLatin1(),programArguments.mid(1));
+  setProgram(program, programArguments.mid(1));
 
   addEnvironmentVariables(environment);
 
-  setEnv("WINDOWID", QString::number(winid));
+  setEnv(QLatin1String("WINDOWID"), QString::number(winid));
 
   // unless the LANGUAGE environment variable has been set explicitly
   // set it to a null string
@@ -185,7 +185,7 @@ int Pty::start(const QString& program,
   // does not have a translation for
   //
   // BR:149300
-  setEnv("LANGUAGE",QString(),false /* do not overwrite existing value if any */);
+  setEnv(QLatin1String("LANGUAGE"),QString(),false /* do not overwrite existing value if any */);
 
   setUseUtmp(addToUtmp);
 

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -252,19 +252,19 @@ void Session::run()
      * As far as i know /bin/sh exists on every unix system.. You could also just put some ifdef __FREEBSD__ here but i think these 2 filechecks are worth
      * their computing time on any system - especially with the problem on arch linux beeing there too.
      */
-    QString exec = QFile::encodeName(_program);
+    QString exec = QString::fromLocal8Bit(QFile::encodeName(_program));
     // if 'exec' is not specified, fall back to default shell.  if that
     // is not set then fall back to /bin/sh
 
     // here we expect full path. If there is no fullpath let's expect it's
     // a custom shell (eg. python, etc.) available in the PATH.
-    if (exec.startsWith("/") || exec.isEmpty())
+    if (exec.startsWith(QLatin1Char('/')) || exec.isEmpty())
     {
-        const QString defaultShell{"/bin/sh"};
+        const QString defaultShell{QLatin1String("/bin/sh")};
 
         QFile excheck(exec);
         if ( exec.isEmpty() || !excheck.exists() ) {
-            exec = getenv("SHELL");
+            exec = QString::fromLocal8Bit(qgetenv("SHELL"));
         }
         excheck.setFileName(exec);
 
@@ -276,7 +276,7 @@ void Session::run()
 
     // _arguments sometimes contain ("") so isEmpty()
     // or count() does not work as expected...
-    QString argsTmp(_arguments.join(" ").trimmed());
+    QString argsTmp(_arguments.join(QLatin1Char(' ')).trimmed());
     QStringList arguments;
     arguments << exec;
     if (argsTmp.length())
@@ -296,7 +296,7 @@ void Session::run()
     // tell the terminal exactly which colors are being used, but instead approximates
     // the color scheme as "black on white" or "white on black" depending on whether
     // the background color is deemed dark or not
-    QString backgroundColorHint = _hasDarkBackground ? "COLORFGBG=15;0" : "COLORFGBG=0;15";
+    QString backgroundColorHint = _hasDarkBackground ? QLatin1String("COLORFGBG=15;0") : QLatin1String("COLORFGBG=0;15");
 
     /* if we do all the checking if this shell exists then we use it ;)
      * Dont know about the arguments though.. maybe youll need some more checking im not sure
@@ -354,7 +354,7 @@ void Session::setUserTitle( int what, const QString & caption )
     }
 
     if (what == 11) {
-        QString colorString = caption.section(';',0,0);
+        QString colorString = caption.section(QLatin1Char(';'),0,0);
         //qDebug() << __FILE__ << __LINE__ << ": setting background colour to " << colorString;
         QColor backColor = QColor(colorString);
         if (backColor.isValid()) { // change color via \033]11;Color\007
@@ -381,7 +381,7 @@ void Session::setUserTitle( int what, const QString & caption )
 
     if (what == 31) {
         QString cwd=caption;
-        cwd=cwd.replace( QRegExp("^~"), QDir::homePath() );
+        cwd=cwd.replace( QRegExp(QLatin1String("^~")), QDir::homePath() );
         emit openUrlRequest(cwd);
     }
 
@@ -588,7 +588,7 @@ QString Session::profileKey() const
 void Session::done(int exitStatus)
 {
     if (!_autoClose) {
-        _userTitle = ("This session is done. Finished");
+        _userTitle = QString::fromLatin1("This session is done. Finished");
         emit titleChanged();
         return;
     }

--- a/lib/ShellCommand.cpp
+++ b/lib/ShellCommand.cpp
@@ -42,7 +42,7 @@ ShellCommand::ShellCommand(const QString & fullCommand)
         QChar ch = fullCommand[i];
 
         const bool isLastChar = ( i == fullCommand.count() - 1 );
-        const bool isQuote = ( ch == '\'' || ch == '\"' );
+        const bool isQuote = ( ch == QLatin1Char('\'') || ch == QLatin1Char('\"') );
 
         if ( !isLastChar && isQuote ) {
             inQuotes = !inQuotes;
@@ -68,7 +68,7 @@ ShellCommand::ShellCommand(const QString & command , const QStringList & argumen
 }
 QString ShellCommand::fullCommand() const
 {
-    return _arguments.join(QChar(' '));
+    return _arguments.join(QLatin1Char(' '));
 }
 QString ShellCommand::command() const
 {
@@ -153,7 +153,7 @@ static bool expandEnv( QString & text )
                 int len = pos2 - pos;
                 QString key = text.mid( pos+1, len-1);
                 QString value =
-                    QString::fromLocal8Bit( ::getenv(key.toLocal8Bit()) );
+                    QString::fromLocal8Bit( qgetenv(key.toLocal8Bit().constData()) );
 
                 if ( !value.isEmpty() ) {
                     expanded = true;

--- a/lib/TerminalCharacterDecoder.cpp
+++ b/lib/TerminalCharacterDecoder.cpp
@@ -124,7 +124,7 @@ void HTMLDecoder::begin(QTextStream* output)
     std::wstring text;
 
     //open monospace span
-    openSpan(text,"font-family:monospace");
+    openSpan(text,QLatin1String("font-family:monospace"));
 
     *output << QString::fromStdWString(text);
 }
@@ -180,19 +180,19 @@ void HTMLDecoder::decodeLine(const Character* const characters, int count, LineP
                 useBold = weight == ColorEntry::Bold;
 
             if (useBold)
-                style.append("font-weight:bold;");
+                style.append(QLatin1String("font-weight:bold;"));
 
             if ( _lastRendition & RE_UNDERLINE )
-                    style.append("font-decoration:underline;");
+                    style.append(QLatin1String("font-decoration:underline;"));
 
             //colours - a colour table must have been defined first
             if ( _colorTable )
             {
-                style.append( QString("color:%1;").arg(_lastForeColor.color(_colorTable).name() ) );
+                style.append( QString::fromLatin1("color:%1;").arg(_lastForeColor.color(_colorTable).name() ) );
 
                 if (!characters[i].isTransparent(_colorTable))
                 {
-                    style.append( QString("background-color:%1;").arg(_lastBackColor.color(_colorTable).name() ) );
+                    style.append( QString::fromLatin1("background-color:%1;").arg(_lastBackColor.color(_colorTable).name() ) );
                 }
             }
 
@@ -237,7 +237,7 @@ void HTMLDecoder::decodeLine(const Character* const characters, int count, LineP
 }
 void HTMLDecoder::openSpan(std::wstring& text , const QString& style)
 {
-    text.append( QString("<span style=\"%1\">").arg(style).toStdWString() );
+    text.append( QString(QLatin1String("<span style=\"%1\">")).arg(style).toStdWString() );
 }
 
 void HTMLDecoder::closeSpan(std::wstring& text)

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -220,14 +220,14 @@ void TerminalDisplay::fontChange(const QFont&)
   // "Base character width on widest ASCII character. This prevents too wide
   //  characters in the presence of double wide (e.g. Japanese) characters."
   // Get the width from representative normal width characters
-  _fontWidth = qRound((double)fm.width(REPCHAR)/(double)strlen(REPCHAR));
+  _fontWidth = qRound((double)fm.width(QLatin1String(REPCHAR))/(double)qstrlen(REPCHAR));
 
   _fixedFont = true;
 
-  int fw = fm.width(REPCHAR[0]);
-  for(unsigned int i=1; i< strlen(REPCHAR); i++)
+  int fw = fm.width(QLatin1Char(REPCHAR[0]));
+  for(unsigned int i=1; i< qstrlen(REPCHAR); i++)
   {
-    if (fw != fm.width(REPCHAR[i]))
+    if (fw != fm.width(QLatin1Char(REPCHAR[i])))
     {
       _fixedFont = false;
       break;
@@ -253,7 +253,7 @@ void TerminalDisplay::calDrawTextAdditionHeight(QPainter& painter)
 {
     QRect test_rect, feedback_rect;
 	test_rect.setRect(1, 1, _fontWidth * 4, _fontHeight);
-	painter.drawText(test_rect, Qt::AlignBottom, LTR_OVERRIDE_CHAR + QString("Mq"), &feedback_rect);
+    painter.drawText(test_rect, Qt::AlignBottom, LTR_OVERRIDE_CHAR + QLatin1String("Mq"), &feedback_rect);
 
 	//qDebug() << "test_rect:" << test_rect << "feeback_rect:" << feedback_rect;
 
@@ -338,7 +338,7 @@ TerminalDisplay::TerminalDisplay(QWidget *parent)
 ,_preserveLineBreaks(false)
 ,_columnSelectionMode(false)
 ,_scrollbarLocation(QTermWidget::NoScrollBar)
-,_wordCharacters(":@-./_~")
+,_wordCharacters(QLatin1String(":@-./_~"))
 ,_bellMode(SystemBeepBell)
 ,_blinking(false)
 ,_hasBlinker(false)
@@ -1278,7 +1278,7 @@ void TerminalDisplay::showResizeNotification()
         _resizeWidget->setMinimumHeight(_resizeWidget->sizeHint().height());
         _resizeWidget->setAlignment(Qt::AlignCenter);
 
-        _resizeWidget->setStyleSheet("background-color:palette(window);border-style:solid;border-width:1px;border-color:palette(dark)");
+        _resizeWidget->setStyleSheet(QLatin1String("background-color:palette(window);border-style:solid;border-width:1px;border-color:palette(dark)"));
 
         _resizeTimer = new QTimer(this);
         _resizeTimer->setSingleShot(true);
@@ -1938,7 +1938,7 @@ void TerminalDisplay::mousePressEvent(QMouseEvent* ev)
 
       Filter::HotSpot *spot = _filterChain->hotSpotAt(charLine, charColumn);
       if (spot && spot->type() == Filter::HotSpot::Link)
-          spot->activate("click-action");
+          spot->activate(QLatin1String("click-action"));
     }
   }
   else if ( ev->button() == Qt::MidButton )
@@ -2458,7 +2458,7 @@ void TerminalDisplay::mouseDoubleClickEvent(QMouseEvent* ev)
      endSel.setX(x);
 
      // In word selection mode don't select @ (64) if at end of word.
-     if ( ( QChar( _image[i].character ) == '@' ) && ( ( endSel.x() - bgnSel.x() ) > 0 ) )
+     if ( ( QChar( _image[i].character ) == QLatin1Char('@') ) && ( ( endSel.x() - bgnSel.x() ) > 0 ) )
        endSel.setX( x - 1 );
 
 
@@ -2600,10 +2600,10 @@ bool TerminalDisplay::focusNextPrevChild( bool next )
 
 QChar TerminalDisplay::charClass(QChar qch) const
 {
-    if ( qch.isSpace() ) return ' ';
+    if ( qch.isSpace() ) return QLatin1Char(' ');
 
     if ( qch.isLetterOrNumber() || _wordCharacters.contains(qch, Qt::CaseInsensitive ) )
-    return 'a';
+    return QLatin1Char('a');
 
     return qch;
 }
@@ -2652,10 +2652,10 @@ void TerminalDisplay::emitSelection(bool useXselection,bool appendReturn)
   QString text = QApplication::clipboard()->text(useXselection ? QClipboard::Selection :
                                                                  QClipboard::Clipboard);
   if(appendReturn)
-    text.append("\r");
+    text.append(QLatin1Char('\r'));
   if ( ! text.isEmpty() )
   {
-    text.replace('\n', '\r');
+    text.replace(QLatin1Char('\n'), QLatin1Char('\r'));
     bracketText(text);
     QKeyEvent e(QEvent::KeyPress, 0, Qt::NoModifier, text);
     emit keyPressedSignal(&e); // expose as a big fat keypress event
@@ -2668,8 +2668,8 @@ void TerminalDisplay::bracketText(QString& text)
 {
     if (bracketedPasteMode())
     {
-        text.prepend("\033[200~");
-        text.append("\033[201~");
+        text.prepend(QLatin1String("\033[200~"));
+        text.append(QLatin1String("\033[201~"));
     }
 }
 
@@ -3102,7 +3102,7 @@ QSize TerminalDisplay::sizeHint() const
 
 void TerminalDisplay::dragEnterEvent(QDragEnterEvent* event)
 {
-  if (event->mimeData()->hasFormat("text/plain"))
+  if (event->mimeData()->hasFormat(QLatin1String("text/plain")))
       event->acceptProposedAction();
   if (event->mimeData()->urls().count())
       event->acceptProposedAction();
@@ -3137,7 +3137,7 @@ void TerminalDisplay::dropEvent(QDropEvent* event)
         dropText += urlText;
 
         if ( i != urls.count()-1 )
-            dropText += ' ';
+            dropText += QLatin1Char(' ');
     }
   }
   else
@@ -3145,7 +3145,7 @@ void TerminalDisplay::dropEvent(QDropEvent* event)
     dropText = event->mimeData()->text();
   }
 
-    emit sendStringToEmu(dropText.toLocal8Bit());
+    emit sendStringToEmu(dropText.toLocal8Bit().constData());
 }
 
 void TerminalDisplay::doDrag()

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -1069,7 +1069,7 @@ void Vt102Emulation::sendKeyEvent( QKeyEvent* event )
         }
         else if ( !entry.text().isEmpty() )
         {
-            textToSend += _codec->fromUnicode(entry.text(true,modifiers));
+            textToSend += _codec->fromUnicode(QString::fromUtf8(entry.text(true,modifiers)));
         }
         else if((modifiers & Qt::ControlModifier) && event->key() >= 0x40 && event->key() < 0x5f) {
             textToSend += (event->key() & 0x1f);

--- a/lib/kpty.cpp
+++ b/lib/kpty.cpp
@@ -496,7 +496,7 @@ void KPty::login(const char * user, const char * remotehost)
 #ifdef HAVE_UTEMPTER
     Q_D(KPty);
 
-    addToUtmp(d->ttyName, remotehost, d->masterFd);
+    addToUtmp(d->ttyName.constData(), remotehost, d->masterFd);
     Q_UNUSED(user);
 #else
 # ifdef HAVE_UTMPX
@@ -582,7 +582,7 @@ void KPty::logout()
 #ifdef HAVE_UTEMPTER
     Q_D(KPty);
 
-    removeLineFromUtmp(d->ttyName, d->masterFd);
+    removeLineFromUtmp(d->ttyName.constData(), d->masterFd);
 #else
     Q_D(KPty);
 

--- a/lib/kptydevice.cpp
+++ b/lib/kptydevice.cpp
@@ -130,7 +130,7 @@ bool KPtyDevicePrivate::_k_canRead()
         }
         if (readBytes < 0) {
             readBuffer.unreserve(available);
-            q->setErrorString("Error reading from PTY");
+            q->setErrorString(QLatin1String("Error reading from PTY"));
             return false;
         }
         readBuffer.unreserve(available - readBytes); // *should* be a no-op
@@ -164,7 +164,7 @@ bool KPtyDevicePrivate::_k_canWrite()
             write(q->masterFd(),
                   writeBuffer.readPointer(), writeBuffer.readSize()));
     if (wroteBytes < 0) {
-        q->setErrorString("Error writing to PTY");
+        q->setErrorString(QLatin1String("Error writing to PTY"));
         return false;
     }
     writeBuffer.free(wroteBytes);
@@ -249,7 +249,7 @@ bool KPtyDevicePrivate::doWait(int msecs, bool reading)
                 break;
             return false;
         case 0:
-            q->setErrorString("PTY operation timed out");
+            q->setErrorString(QLatin1String("PTY operation timed out"));
             return false;
         default:
             if (FD_ISSET(q->masterFd(), &rfds)) {
@@ -305,7 +305,7 @@ bool KPtyDevice::open(OpenMode mode)
         return true;
 
     if (!KPty::open()) {
-        setErrorString("Error opening PTY");
+        setErrorString(QLatin1String("Error opening PTY"));
         return false;
     }
 
@@ -319,7 +319,7 @@ bool KPtyDevice::open(int fd, OpenMode mode)
     Q_D(KPtyDevice);
 
     if (!KPty::open(fd)) {
-        setErrorString("Error opening PTY");
+        setErrorString(QLatin1String("Error opening PTY"));
         return false;
     }
 

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -64,7 +64,7 @@ Session *TermWidgetImpl::createSession(QWidget* parent)
 {
     Session *session = new Session(parent);
 
-    session->setTitle(Session::NameRole, "QTermWidget");
+    session->setTitle(Session::NameRole, QLatin1String("QTermWidget"));
 
     /* Thats a freaking bad idea!!!!
      * /bin/bash is not there on every system
@@ -75,11 +75,11 @@ Session *TermWidgetImpl::createSession(QWidget* parent)
      */
     //session->setProgram("/bin/bash");
 
-    session->setProgram(getenv("SHELL"));
+    session->setProgram(QString::fromLocal8Bit(qgetenv("SHELL")));
 
 
 
-    QStringList args("");
+    QStringList args = QStringList(QString());
     session->setArguments(args);
     session->setAutoClose(true);
 
@@ -90,7 +90,7 @@ Session *TermWidgetImpl::createSession(QWidget* parent)
 
     session->setDarkBackground(true);
 
-    session->setKeyBindings("");
+    session->setKeyBindings(QString());
     return session;
 }
 
@@ -202,12 +202,12 @@ void QTermWidget::changeDir(const QString & dir)
     */
     QString strCmd;
     strCmd.setNum(getShellPID());
-    strCmd.prepend("ps -j ");
-    strCmd.append(" | tail -1 | awk '{ print $5 }' | grep -q \\+");
+    strCmd.prepend(QLatin1String("ps -j "));
+    strCmd.append(QLatin1String(" | tail -1 | awk '{ print $5 }' | grep -q \\+"));
     int retval = system(strCmd.toStdString().c_str());
 
     if (!retval) {
-        QString cmd = "cd " + dir + "\n";
+        QString cmd = QLatin1String("cd ") + dir + QLatin1Char('\n');
         sendText(cmd);
     }
 }
@@ -274,7 +274,7 @@ void QTermWidget::init(int startnow)
 
     for (const QString& dir : dirs) {
         qDebug() << "Trying to load translation file from dir" << dir;
-        if (m_translator->load(QLocale::system(), "qtermwidget", "_", dir)) {
+        if (m_translator->load(QLocale::system(), QLatin1String("qtermwidget"), QLatin1String(QLatin1String("_")), dir)) {
             qApp->installTranslator(m_translator);
             qDebug() << "Translations found in" << dir;
             break;
@@ -325,7 +325,7 @@ void QTermWidget::init(int startnow)
 //    m_impl->m_terminalDisplay->setSize(80, 40);
 
     QFont font = QApplication::font();
-    font.setFamily("Monospace");
+    font.setFamily(QLatin1String("Monospace"));
     font.setPointSize(10);
     font.setStyleHint(QFont::TypeWriter);
     setTerminalFont(font);
@@ -403,7 +403,7 @@ QString QTermWidget::workingDirectory()
     // Christian Surlykke: On linux we could look at /proc/<pid>/cwd which should be a link to current
     // working directory (<pid>: process id of the shell). I don't know about BSD.
     // Maybe we could just offer it when running linux, for a start.
-    QDir d(QString("/proc/%1/cwd").arg(getShellPID()));
+    QDir d(QString::fromLatin1("/proc/%1/cwd").arg(getShellPID()));
     if (!d.exists())
     {
         qDebug() << "Cannot find" << d.dirName();

--- a/lib/tools.cpp
+++ b/lib/tools.cpp
@@ -16,23 +16,23 @@ QString get_kb_layout_dir()
 #else
 //    qDebug() << __FILE__ << __FUNCTION__;
 
-    QString rval = "";
-    QString k(KB_LAYOUT_DIR);
+    QString rval = QString();
+    QString k(QLatin1String(KB_LAYOUT_DIR));
     QDir d(k);
 
     qDebug() << "default KB_LAYOUT_DIR: " << k;
 
     if (d.exists())
     {
-        rval = k.append("/");
+        rval = k.append(QLatin1Char('/'));
         return rval;
     }
 
     // subdir in the app location
-    d.setPath(QCoreApplication::applicationDirPath() + "/kb-layouts/");
+    d.setPath(QCoreApplication::applicationDirPath() + QLatin1String("/kb-layouts/"));
     //qDebug() << d.path();
     if (d.exists())
-        return QCoreApplication::applicationDirPath() + "/kb-layouts/";
+        return QCoreApplication::applicationDirPath() + QLatin1String("/kb-layouts/");
 #ifdef Q_WS_MAC
     d.setPath(QCoreApplication::applicationDirPath() + "/../Resources/kb-layouts/");
     if (d.exists())
@@ -66,22 +66,22 @@ const QStringList get_color_schemes_dirs()
 //    qDebug() << __FILE__ << __FUNCTION__;
 
     QStringList rval;
-    QString k(COLORSCHEMES_DIR);
+    QString k(QLatin1String(COLORSCHEMES_DIR));
     QDir d(k);
 
 //    qDebug() << "default COLORSCHEMES_DIR: " << k;
 
     if (d.exists())
-        rval << k.append("/");
+        rval << k.append(QLatin1Char('/'));
 
     // subdir in the app location
-    d.setPath(QCoreApplication::applicationDirPath() + "/color-schemes/");
+    d.setPath(QCoreApplication::applicationDirPath() + QLatin1String("/color-schemes/"));
     //qDebug() << d.path();
     if (d.exists())
     {
         if (!rval.isEmpty())
             rval.clear();
-        rval << (QCoreApplication::applicationDirPath() + "/color-schemes/");
+        rval << (QCoreApplication::applicationDirPath() + QLatin1String("/color-schemes/"));
     }
 #ifdef Q_WS_MAC
     d.setPath(QCoreApplication::applicationDirPath() + "/../Resources/color-schemes/");


### PR DESCRIPTION
* Disables automatic conversions from 8-bit strings (char *) to unicode
  QStrings.
* Disables automatic conversion from QString to 8-bit strings (char *).
* Disables automatic conversions from QByteArray to const char * or const
  void *.
* Disables automatic conversions from QString (or char *) to QUrl.
* Use QStringBuilder for more efficient string creation.

It make us aware of string and encoding conversions.