### PR TITLE
use openpty() on mac

### DIFF
--- a/lib/kpty.cpp
+++ b/lib/kpty.cpp
@@ -37,6 +37,11 @@
 #define HAVE_UTIL_H
 #endif
 
+#if defined(__APPLE__)
+#define HAVE_OPENPTY
+#define HAVE_UTIL_H
+#endif
+
 #ifdef __sgi
 #define __svr4__
 #endif
@@ -169,12 +174,14 @@ KPtyPrivate::~KPtyPrivate()
 {
 }
 
+#ifndef HAVE_OPENPTY
 bool KPtyPrivate::chownpty(bool)
 {
 //    return !QProcess::execute(KStandardDirs::findExe("kgrantpty"),
 //        QStringList() << (grant?"--grant":"--revoke") << QString::number(masterFd));
     return true;
 }
+#endif
 
 /////////////////////////////
 // public member functions //
@@ -221,7 +228,7 @@ bool KPty::open()
     if (::openpty( &d->masterFd, &d->slaveFd, ptsn, 0, 0)) {
         d->masterFd = -1;
         d->slaveFd = -1;
-        qWarning(175) << "Can't open a pseudo teletype";
+        qWarning() << "Can't open a pseudo teletype";
         return false;
     }
     d->ttyName = ptsn;


### PR DESCRIPTION
This commit includes a 10-year-old fix from upstream kpty
https://github.com/KDE/kdelibs/commit/fff22a70fc636eaea3a1443d66641067df01fd28

On macOS, at least on High Sierra 10.13.6, opening PTYs via files under /dev/ (like how KPty does on Linux) fails with "Resource temporarily unavailable", and openpty() works fine.

Looks like openpty() has been there since 10.6 (Snow Leopard) - https://www.unix.com/man-page/osx/3/openpty/