### PR TITLE
Fix handling of ST (String Terminator) for OSC (Operating System Commands)

### DIFF
--- a/lib/Vt102Emulation.h
+++ b/lib/Vt102Emulation.h
@@ -143,6 +143,7 @@ private:
   int argv[MAXARGS];
   int argc;
   void initTokenizer();
+  int prevCC;
 
   // Set of flags for each of the ASCII characters which indicates
   // what category they fall into (printable character, control, digit etc.)


### PR DESCRIPTION
This is an improvement over a combination of

https://github.com/KDE/konsole/commit/7a41b73b46d1f774e82eb64a8b66920e411ccd3c
https://github.com/KDE/konsole/commit/d547d1d177bd0582df95a5d50dc3b37e0636748e

Fixes https://github.com/lxqt/qtermwidget/issues/163
Fixes https://github.com/lxqt/qtermwidget/issues/212