### PR TITLE
Make Backspace behaves the same as xterm

### DIFF
--- a/lib/kb-layouts/default.keytab
+++ b/lib/kb-layouts/default.keytab
@@ -33,8 +33,13 @@ key Return-Shift+NewLine : "\r\n"
 key Return+Shift         : "\EOM"
 
 # Backspace and Delete codes are preserving CTRL-H.
+#
+# Backspace without CTRL sends '^H'; this matches XTerm behaviour
+# BS, hex \x08, \b
+key Backspace -Control : "\b"
 
-key Backspace      : "\x7f"
+# Match xterm behaviour: Backspace sends '^?' when Control is pressed
+key Backspace +Control : "\x7f"
 
 # Arrow keys in VT52 mode
 # shift up/down are reserved for scrolling.


### PR DESCRIPTION
Fixes https://github.com/lxqt/qtermwidget/issues/1

Notes about other terminals:

Konsole:
^? for backspace and ^H for ctrl+backspace

Gnome Terminal (VTE3):
- ^? for backspace and ^H for ctrl+backspace by default, and
- ^H for backspace and ^? for ctrl+backspace if the option
  "Backspace key generates:" is set to "Control-H"