### PR TITLE
Revert "Rework on memory management of filter-related objects"

### DIFF
--- a/lib/Filter.cpp
+++ b/lib/Filter.cpp
@@ -22,7 +22,6 @@
 
 // System
 #include <iostream>
-#include <memory>
 
 // Qt
 #include <QAction>
@@ -193,12 +192,7 @@ Filter::~Filter()
 }
 void Filter::reset()
 {
-    for (HotSpot* const currentHotSpot : qAsConst(_hotspotList)) {
-        if (currentHotSpot->hasAnotherParent()) {
-            continue;
-        }
-        delete currentHotSpot;
-    }
+    qDeleteAll(_hotspotList);
     _hotspots.clear();
     _hotspotList.clear();
 }
@@ -285,18 +279,15 @@ Filter::HotSpot* Filter::hotSpotAt(int line , int column) const
 }
 
 Filter::HotSpot::HotSpot(int startLine , int startColumn , int endLine , int endColumn)
-    : _hasAnotherParent(false)
-    , _startLine(startLine)
+    : _startLine(startLine)
     , _startColumn(startColumn)
     , _endLine(endLine)
     , _endColumn(endColumn)
     , _type(NotSpecified)
 {
 }
-QList<QAction*> Filter::HotSpot::actions(QWidget* parent)
+QList<QAction*> Filter::HotSpot::actions()
 {
-    Q_UNUSED(parent);
-
     return QList<QAction*>();
 }
 int Filter::HotSpot::startLine() const
@@ -508,28 +499,14 @@ FilterObject* UrlFilter::HotSpot::getUrlObject() const
     return _urlObject;
 }
 
-class UrlAction : public QAction {
-public:
-    UrlAction(QWidget* parent, std::shared_ptr<UrlFilter::HotSpot> hotspotPtr)
-        : QAction(parent)
-        , _hotspotPtr(hotspotPtr)
-    {
-    }
-
-private:
-    std::shared_ptr<UrlFilter::HotSpot> _hotspotPtr;
-};
-
-QList<QAction*> UrlFilter::HotSpot::actions(QWidget* parent)
+QList<QAction*> UrlFilter::HotSpot::actions()
 {
-    this->_hasAnotherParent = true;
     QList<QAction*> list;
 
     const UrlType kind = urlType();
 
-    std::shared_ptr<UrlFilter::HotSpot> hotspotPtr(this);
-    UrlAction* openAction = new UrlAction(parent, hotspotPtr);
-    UrlAction* copyAction = new UrlAction(parent, hotspotPtr);
+    QAction* openAction = new QAction(_urlObject);
+    QAction* copyAction = new QAction(_urlObject);;
 
     Q_ASSERT( kind == StandardUrl || kind == Email );
 

--- a/lib/Filter.h
+++ b/lib/Filter.h
@@ -115,15 +115,11 @@ public:
         * Returns a list of actions associated with the hotspot which can be used in a
         * menu or toolbar
         */
-       virtual QList<QAction*> actions(QWidget* parent);
-
-       bool hasAnotherParent() const { return _hasAnotherParent; }
+       virtual QList<QAction*> actions();
 
     protected:
        /** Sets the type of a hotspot.  This should only be set once */
        void setType(Type type);
-
-       bool   _hasAnotherParent;
 
     private:
        int    _startLine;
@@ -131,6 +127,7 @@ public:
        int    _endLine;
        int    _endColumn;
        Type _type;
+
     };
 
     /** Constructs a new filter. */
@@ -259,7 +256,7 @@ public:
 
         FilterObject* getUrlObject() const;
 
-        virtual QList<QAction*> actions(QWidget* parent);
+        virtual QList<QAction*> actions();
 
         /**
          * Open a web browser at the current URL.  The url itself can be determined using

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -1962,14 +1962,14 @@ void TerminalDisplay::mousePressEvent(QMouseEvent* ev)
   }
 }
 
-QList<QAction*> TerminalDisplay::filterActions(const QPoint& position, QWidget* parent)
+QList<QAction*> TerminalDisplay::filterActions(const QPoint& position)
 {
   int charLine, charColumn;
   getCharacterPosition(position,charLine,charColumn);
 
   Filter::HotSpot* spot = _filterChain->hotSpotAt(charLine,charColumn);
 
-  return spot ? spot->actions(parent) : QList<QAction*>();
+  return spot ? spot->actions() : QList<QAction*>();
 }
 
 void TerminalDisplay::mouseMoveEvent(QMouseEvent* ev)

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -158,7 +158,7 @@ public:
      * Returns a list of menu actions created by the filters for the content
      * at the given @p position.
      */
-    QList<QAction*> filterActions(const QPoint& position, QWidget* parent);
+    QList<QAction*> filterActions(const QPoint& position);
 
     /** Returns true if the cursor is set to blink or false otherwise. */
     bool blinkingCursor() { return _hasBlinkingCursor; }

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -671,9 +671,9 @@ Filter::HotSpot* QTermWidget::getHotSpotAt(int row, int column) const
     return m_impl->m_terminalDisplay->filterChain()->hotSpotAt(row, column);
 }
 
-QList<QAction*> QTermWidget::filterActions(const QPoint& position, QWidget* parent)
+QList<QAction*> QTermWidget::filterActions(const QPoint& position)
 {
-    return m_impl->m_terminalDisplay->filterActions(position, parent);
+    return m_impl->m_terminalDisplay->filterActions(position);
 }
 
 int QTermWidget::getPtySlaveFd() const

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -186,7 +186,7 @@ public:
     /*
      * Proxy for TerminalDisplay::filterActions
      * */
-    QList<QAction*> filterActions(const QPoint& position, QWidget* parent);
+    QList<QAction*> filterActions(const QPoint& position);
 
     /**
      * Returns a pty slave file descriptor.


### PR DESCRIPTION
This reverts commit 0154e036c702b82ebe4b12bed30085247451362c.

Reverted PR: #186

My approach is basically broken, leading to crashes in https://github.com/lxqt/qtermwidget/issues/241. You can observe quite a few invalid read operations from valgrind after closing the context menu of links. The cause appears to be that URLAction objects delete hotspots after the context menu is closed as hotspots are stored in a shared_ptr and URLAction objects are the only ones who hold references to them.

Need a better approach. I'm afraid I don't have time to finish it before the upcoming 0.14 release, so I revert relevant changes first.