### PR TITLE
KPty: Don't conditionalize chownpty existence on HAVE_OPENPTY

### DIFF
--- a/lib/kpty.cpp
+++ b/lib/kpty.cpp
@@ -174,14 +174,12 @@ KPtyPrivate::~KPtyPrivate()
 {
 }
 
-#ifndef HAVE_OPENPTY
 bool KPtyPrivate::chownpty(bool)
 {
 //    return !QProcess::execute(KStandardDirs::findExe("kgrantpty"),
 //        QStringList() << (grant?"--grant":"--revoke") << QString::number(masterFd));
     return true;
 }
-#endif
 
 /////////////////////////////
 // public member functions //

--- a/lib/kpty_p.h
+++ b/lib/kpty_p.h
@@ -35,9 +35,7 @@ public:
     KPtyPrivate(KPty* parent);
     virtual ~KPtyPrivate();
 
-#ifndef HAVE_OPENPTY
     bool chownpty(bool grant);
-#endif
 
     int masterFd;
     int slaveFd;


### PR DESCRIPTION
Fixes https://github.com/lxqt/qtermwidget/issues/250.

This fixes the build on Mac, which is the only place where HAVE_OPENPTY is actually defined.

I think this is the correct approach, because currently, `HAVE_OPENPTY` is being used to conditionalize two things:
* the use of `openpty()`
* the existence of `KPtyPrivate::chownpty(bool)`

Conditionalizing the use of `openpty()` makes sense. But conditionalizing the existence of `KPtyPrivate::chownpty(bool)` doesn't seem to, especially because the _use_ of `KPtyPrivate::chownpty` is not conditionalized; e.g. [here in KPty::close()](https://github.com/lxqt/qtermwidget/blob/456e3568092d2d111c61e414cb20743f24c9388c/lib/kpty.cpp#L467) and [here in KPty::open()](https://github.com/lxqt/qtermwidget/blob/456e3568092d2d111c61e414cb20743f24c9388c/lib/kpty.cpp#L333).

This PR de-conditionalizes the existence of `chownpty`, making it always exist.

After applying this patch, QTermWidget builds for me on macOS. I'm not sure if it works right, because I don't know how to test it yet.