### PR TITLE
Replace Q_WS_MAC with Q_OS_MACOS for Qt 5 compatibility

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
     mainWindow->setMenuBar(menuBar);
 
     QFont font = QApplication::font();
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MACOS
     font.setFamily("Monaco");
 #elif defined(Q_WS_QWS)
     font.setFamily("fixed");


### PR DESCRIPTION
Fixes #253.

The Q_WS_MAC Window Server macro is no longer defined in Qt 5: https://doc.qt.io/qt-5/macos-issues.html#compile-time-flags. This is causing the example program to pick the wrong name for the default font family on macOS, so it's falling back to Arial, a variable-width font.

This PR fixes the OS detection in the example program, fixing its font on macOS.

Pre-req for https://github.com/lxqt/qterminal/issues/533.