### PR TITLE
example: Fix "Find" menu item name

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
     QMenuBar *menuBar = new QMenuBar(mainWindow);
     QMenu *actionsMenu = new QMenu("Actions", menuBar);
     menuBar->addMenu(actionsMenu);
-    actionsMenu->addAction("Find..", console, SLOT(toggleShowSearchBar()), QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_F));
+    actionsMenu->addAction("Find...", console, SLOT(toggleShowSearchBar()), QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_F));
     actionsMenu->addAction("About Qt", &app, SLOT(aboutQt()));
     mainWindow->setMenuBar(menuBar);
 


### PR DESCRIPTION
In the example program, it has a "Find.." menu item. It looks like it should be "Find...", with three dots (ellipses) instead of just two.