### PR TITLE
cmake: set CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,13 @@ include(LXQtTranslateTs)
 include(LXQtCompilerSettings NO_POLICY_SCOPE)
 include(LXQtCreatePkgConfigFile)
 
+if(APPLE)
+    if(CMAKE_VERSION VERSION_GREATER 3.9)
+        cmake_policy(SET CMP0068 NEW)
+        set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
+    endif()
+endif()
+
 set(QTERMWIDGET_LIBRARY_NAME qtermwidget5)
 
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/qterminal/issues/561.
Required for https://github.com/lxqt/qterminal/issues/533.

This fixes a dylib linkage issue in client programs on macOS.