### PR TITLE
Fix default font on macOS

### DIFF
--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -33,6 +33,12 @@
 #include "SearchBar.h"
 #include "qtermwidget.h"
 
+#ifdef Q_OS_MACOS
+// Qt does not support fontconfig on macOS, so we need to use a "real" font name.
+#define DEFAULT_FONT_FAMILY                   "Menlo"
+#else
+#define DEFAULT_FONT_FAMILY                   "Monospace"
+#endif
 
 #define STEP_ZOOM 1
 
@@ -321,7 +327,7 @@ void QTermWidget::init(int startnow)
 //    m_impl->m_terminalDisplay->setSize(80, 40);
 
     QFont font = QApplication::font();
-    font.setFamily(QLatin1String("Monospace"));
+    font.setFamily(QLatin1String(DEFAULT_FONT_FAMILY));
     font.setPointSize(10);
     font.setStyleHint(QFont::TypeWriter);
     setTerminalFont(font);


### PR DESCRIPTION
Follows up https://github.com/lxqt/qterminal/pull/563.

Qt does not support fontconfig on macOS, so we need to work around it and provide a "real" font family name for the default font. Otherwise, "Monospace" will be unrecognized and it will fall back to a variable-width font.

Before this change, `qterminal` issues a warning about variable-width font use:
```
$ qterminal
Cannot connect to the D-Bus session bus.
[...]
Using a variable-width font in the terminal.  This may cause performance degradation and display/alignment errors.
[...]
```

With this PR, the warning goes away, and macOS programs that are embedding QTermWidget without specifying a font will still get a monospaced font.

Menlo is installed with macOS, so it is always available on that OS. It is the default font used by Terminal.app and Xcode.