### PR TITLE
Fix Ctrl-modified inputs on Mac by swapping Qt::ControlModifier and Qt::MetaModifier

### DIFF
--- a/lib/KeyboardTranslator.cpp
+++ b/lib/KeyboardTranslator.cpp
@@ -50,6 +50,13 @@ const QByteArray KeyboardTranslatorManager::defaultTranslatorText(
 "key Tab : \"\\t\""
 );
 
+#ifdef Q_OS_MAC
+// On Mac, Qt::ControlModifier means Cmd, and MetaModifier means Ctrl
+const Qt::KeyboardModifier KeyboardTranslator::CTRL_MOD = Qt::MetaModifier;
+#else
+const Qt::KeyboardModifier KeyboardTranslator::CTRL_MOD = Qt::ControlModifier;
+#endif
+
 KeyboardTranslatorManager::KeyboardTranslatorManager()
     : _haveLoadedAll(false)
 {
@@ -613,6 +620,11 @@ bool KeyboardTranslator::Entry::matches(int keyCode ,
                                         Qt::KeyboardModifiers modifiers,
                                         States testState) const
 {
+#ifdef Q_OS_MAC
+    // On Mac, arrow keys are considered part of keypad. Ignore that.
+    modifiers &= ~Qt::KeypadModifier;
+#endif
+
     if ( _keyCode != keyCode )
         return false;
 

--- a/lib/KeyboardTranslator.h
+++ b/lib/KeyboardTranslator.h
@@ -314,6 +314,9 @@ public:
     /** Returns a list of all entries in the translator. */
     QList<Entry> entries() const;
 
+    /** The modifier code for the actual Ctrl key on this OS. */
+    static const Qt::KeyboardModifier CTRL_MOD;
+
 private:
 
     QMultiHash<int,Entry> _entries; // entries in this keyboard translation,
@@ -558,8 +561,8 @@ inline QByteArray KeyboardTranslator::Entry::text(bool expandWildCards,Qt::Keybo
     {
         int modifierValue = 1;
         modifierValue += oneOrZero(modifiers & Qt::ShiftModifier);
-        modifierValue += oneOrZero(modifiers & Qt::AltModifier)     << 1;
-        modifierValue += oneOrZero(modifiers & Qt::ControlModifier) << 2;
+        modifierValue += oneOrZero(modifiers & Qt::AltModifier) << 1;
+        modifierValue += oneOrZero(modifiers & KeyboardTranslator::CTRL_MOD) << 2;
 
         for (int i=0;i<_text.length();i++)
         {

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -1025,7 +1025,7 @@ void Vt102Emulation::sendKeyEvent( QKeyEvent* event )
         states |= KeyboardTranslator::ApplicationKeypadState;
 
     // check flow control state
-    if (modifiers & Qt::ControlModifier)
+    if (modifiers & KeyboardTranslator::CTRL_MOD)
     {
         switch (event->key()) {
         case Qt::Key_S:
@@ -1080,7 +1080,7 @@ void Vt102Emulation::sendKeyEvent( QKeyEvent* event )
         {
             textToSend += _codec->fromUnicode(QString::fromUtf8(entry.text(true,modifiers)));
         }
-        else if((modifiers & Qt::ControlModifier) && event->key() >= 0x40 && event->key() < 0x5f) {
+        else if((modifiers & KeyboardTranslator::CTRL_MOD) && event->key() >= 0x40 && event->key() < 0x5f) {
             textToSend += (event->key() & 0x1f);
         }
         else if(event->key() == Qt::Key_Tab) {


### PR DESCRIPTION
Fixes https://github.com/lxqt/qterminal/issues/569.

Ctrl-arrow navigation and other Ctrl-modified keys currently aren't working on macOS.

It looks like this is because on Mac, [Qt's `Qt::ControlModifier` and `Qt::MetaModifier` are swapped](https://doc.qt.io/qt-5/qt.html#KeyboardModifier-enum).

This PR adds a local constant that un-swaps them for the purposes of Ctrl. The code is pretty much a straight lift of [@yan12125's old MacPorts keyboard modifiers patch](https://gitlab.com/yan12125/macports-overlay/commit/f266c2d0a8d6813a25e0675a6ba5c2b4b0276086#68ee1803113ed81e5431e1c5f19074ed53c3ecf6).

In local testing on my Mac with this patch, Ctrl-arrow navigation, Ctrl-V verbatim insert, and other Ctrl-modified actions start working again in bash.