### PR TITLE
Add QTermWidget::saveHistory and QTermWidget::sendCommand.

### DIFF
--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -751,3 +751,11 @@ int QTermWidget::getMargin() const
 {
     return m_impl->m_terminalDisplay->margin();
 }
+
+void QTermWidget::saveHistory(QIODevice *device)
+{
+    QTextStream stream(device);
+    PlainTextDecoder decoder;
+    decoder.begin(&stream);
+    m_impl->m_session->emulation()->writeToStream(&decoder, 0, m_impl->m_session->emulation()->lineCount());
+}

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -287,6 +287,7 @@ public slots:
 
     void toggleShowSearchBar();
 
+    void saveHistory(QIODevice *device);
 protected:
     void resizeEvent(QResizeEvent *) override;
 


### PR DESCRIPTION
This enables an application to implement the functionality of easily
opening the entire history as a file in your favorite editor.