### PR TITLE
Initial Travis CI setup

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,0 +1,6 @@
+set -ex
+
+mkdir build
+cd build
+cmake -DBUILD_EXAMPLE=ON -DQTERMWIDGET_BUILD_PYTHON_BINDING=ON ..
+make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: cpp
+
+sudo: required
+
+services:
+  - docker
+
+script:
+  - "curl -s https://raw.githubusercontent.com/mikkeloscar/arch-travis/master/arch-travis.sh | bash"
+
+arch:
+  repos:
+    - archlinuxcn=https://cdn.repo.archlinuxcn.org/$arch
+  packages:
+    # See *depends in https://github.com/archlinuxcn/repo/blob/master/archlinuxcn/qtermwidget-git/PKGBUILD
+    - git
+    - cmake
+    - lxqt-build-tools-git
+    - qt5-tools
+    - python-pyqt5
+    - python-sip
+    - sip
+    # Using the -nostatx variant as Travis builders come with older kernels
+    - qt5-base-nostatx
+  script: bash ./.ci/build.sh


### PR DESCRIPTION
This is a basic Travis CI setup on Arch Linux. It uses [arch-travis](https://github.com/mikkeloscar/arch-travis) to test qtermwidget on Arch Linux, unofficial [`[archlinuxcn]`](https://github.com/archlinuxcn/repo/) repository for daily build of LXQt dependencies. Here's a sample build for my fork: https://travis-ci.com/yan12125/qtermwidget/builds/108224276.

In [archlinuxcn], all LXQt packages are maintained by me. Those packages are built at 1:00am, 9:00am and 17:00 pm UTC+8.

@agaida: Seems I have no permission to set up Travis CI integration for the LXQt organization. Could you have a look?