### PR TITLE
Completed the support for transient scrollbars

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -960,8 +960,10 @@ void TerminalDisplay::scrollImage(int lines , const QRect& screenWindowRegion)
     // Set the QT_FLUSH_PAINT environment variable to '1' before starting the
     // application to monitor repainting.
     //
-    int scrollBarWidth = _scrollBar->isHidden() ? 0 : _scrollBar->width();
-    const int SCROLLBAR_CONTENT_GAP = 1;
+    int scrollBarWidth = _scrollBar->isHidden() ? 0 :
+                         _scrollBar->style()->styleHint(QStyle::SH_ScrollBar_Transient, nullptr, _scrollBar) ?
+                         0 : _scrollBar->width();
+    const int SCROLLBAR_CONTENT_GAP = scrollBarWidth == 0 ? 0 : 1;
     QRect scrollRect;
     if ( _scrollbarLocation == QTermWidget::ScrollBarLeft )
     {


### PR DESCRIPTION
Transient scrollbars don't take space but that wasn't considered in a small part of the code. This patch completes https://github.com/lxqt/qtermwidget/commit/2b7c2b38edd69613f5c1ec67958c18f438d27e4f

I encountered a small problem during a big compilation (qt), made and applied the patch and, by chance, had another big compilation (qtcreator) afterward. The test was successful, as expected.