### PR TITLE
Fix numpad handling and add entries for numpad 5

### DIFF
--- a/lib/KeyboardTranslator.cpp
+++ b/lib/KeyboardTranslator.cpp
@@ -632,7 +632,7 @@ bool KeyboardTranslator::Entry::matches(int keyCode ,
         return false;
 
     // if modifiers is non-zero, the 'any modifier' state is implicit
-    if ( modifiers != 0 )
+    if ( (modifiers & ~Qt::KeypadModifier) != 0 )
         testState |= AnyModifierState;
 
     if ( (testState & _stateMask) != (_state & _stateMask) )

--- a/lib/kb-layouts/default.keytab
+++ b/lib/kb-layouts/default.keytab
@@ -114,6 +114,9 @@ key Delete        +KeyPad : "\E[3~"
 key PgUp    -Shift+KeyPad : "\E[5~"
 key PgDown  -Shift+KeyPad : "\E[6~"
 
+key Clear -AnyMod+KeyPad+AppKeyPad : "\E[OE"
+key Clear +AnyMod+KeyPad+AppKeyPad : "\E[1;*E"
+
 # other grey PC keys
 
 key Enter+NewLine : "\r\n"
@@ -178,4 +181,3 @@ key PgDown  +Shift-AppScreen : scrollPageDown
 key End     +Shift-AppScreen : scrollDownToBottom
 
 key ScrollLock     : scrollLock
-


### PR DESCRIPTION
KP_Clear is mapped from numpad 5 on non-Apple keyboards according to Qt
doc [1]. It's mapped from KP_Begin from XKB on X11.

Tests: with numlock off,

numpad 5 => "\e[OE"
Ctrl + numpad 5 => "\e[1;5E"
Alt + numpad 5 => "\e[1;3E"
Shift + numpad 5 => "5"

These results are the same as VTE3 0.56.3. On xterm 346, Shift + numpad
5 generates "\eO2u". However, Qt returns 5 instead of KP_Clear if Shift
is hold even with numlock off, so implementing Shift + numpad 5 might be
rather complicated. As a side note, shifted keypad sequences can be
found in emacs sources [2].

Note that on Wayfire (wlroots-based Wayland compositor), numpad 5 with
numlock off generates an event without Qt::KeypadModifier. Further
investigation needed.

Ref: https://github.com/lxqt/qtermwidget/issues/117

[1] https://doc.qt.io/qt-5/qt.html#Key-enum
[2] https://github.com/emacs-mirror/emacs/blame/master/lisp/term/xterm.el