### PR TITLE
Use QRectF for cursor drawing, fix artifacts in cursor moving on HiDPI display

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -751,7 +751,7 @@ void TerminalDisplay::drawCursor(QPainter& painter,
                                  const QColor& /*backgroundColor*/,
                                  bool& invertCharacterColor)
 {
-    QRect cursorRect = rect;
+    QRectF cursorRect = rect;
     cursorRect.setHeight(_fontHeight - _lineSpacing - 1);
 
     if (!_cursorBlinking)
@@ -765,12 +765,12 @@ void TerminalDisplay::drawCursor(QPainter& painter,
        {
             // draw the cursor outline, adjusting the area so that
             // it is draw entirely inside 'rect'
-            int penWidth = qMax(1,painter.pen().width());
+            float penWidth = qMax(1,painter.pen().width());
 
             painter.drawRect(cursorRect.adjusted(penWidth/2,
                                                  penWidth/2,
-                                                 - penWidth/2 - penWidth%2,
-                                                 - penWidth/2 - penWidth%2));
+                                                 - penWidth/2,
+                                                 - penWidth/2));
             if ( hasFocus() )
             {
                 painter.fillRect(cursorRect, _cursorColor.isValid() ? _cursorColor : foregroundColor);


### PR DESCRIPTION
Fixes https://github.com/lxqt/qtermwidget/issues/115

Before this fix, the cursor is been drawed outside the rectangle in HiDPI display (one more pixel in top).  According to [this](https://doc.qt.io/qt-5/highdpi.html), we should "Always use the qreal versions of the QPainter drawing API" to support HiDPI display.

Note that there's other places in `TerminalDisplay.cpp` that is not using qreal versions of QPainter API yet, which should also be fixed in future.