### PR TITLE
Fix compilation on NetBSD

### DIFF
--- a/lib/kpty.cpp
+++ b/lib/kpty.cpp
@@ -27,12 +27,12 @@
 #include <QtDebug>
 
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 #define HAVE_LOGIN
 #define HAVE_LIBUTIL_H
 #endif
 
-#if defined(__OpenBSD__)
+#if defined(__OpenBSD__) || defined(__NetBSD__)
 #define HAVE_LOGIN
 #define HAVE_UTIL_H
 #endif


### PR DESCRIPTION
Like OpenBSD, NetBSD has util.h, not libutil.h.