### PR TITLE
feat: add sendKeyEvent() api

### DIFF
--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -568,6 +568,11 @@ void Session::sendText(const QString & text) const
     _emulation->sendText(text);
 }
 
+void Session::sendKeyEvent(QKeyEvent* e) const
+{
+    _emulation->sendKeyEvent(e);
+}
+
 Session::~Session()
 {
     delete _emulation;

--- a/lib/Session.h
+++ b/lib/Session.h
@@ -314,6 +314,8 @@ public:
      */
     void sendText(const QString & text) const;
 
+    void sendKeyEvent(QKeyEvent* e) const;
+
     /**
      * Returns the process id of the terminal process.
      * This is the id used by the system API to refer to the process.

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -507,6 +507,11 @@ void QTermWidget::sendText(const QString &text)
     m_impl->m_session->sendText(text);
 }
 
+void QTermWidget::sendKeyEvent(QKeyEvent *e)
+{
+    m_impl->m_session->sendKeyEvent(e);
+}
+
 void QTermWidget::resizeEvent(QResizeEvent*)
 {
 //qDebug("global window resizing...with %d %d", this->size().width(), this->size().height());

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -125,6 +125,9 @@ public:
     // Send some text to terminal
     void sendText(const QString & text);
 
+    // Send key event to terminal
+    void sendKeyEvent(QKeyEvent* e);
+
     // Sets whether flow control is enabled
     void setFlowControlEnabled(bool enabled);
 


### PR DESCRIPTION
This Pull Request add the sendKeyEvent interface for sending key event to the terminal emulater.

Reason for this API is, in some case I found I cannot send a key event directly by using `QCoreApplication::postEvent` with a constructed `QKeyEvent`. For my case is when creating a QtCreator plugin, the terminal instance will never receive the key event sent via `QCoreApplication::postEvent` (I'm new to QtCreator plugin development so correct me if I'm wrong).

Although we can send key event by using `sendText()` but having a `sendKeyEvent()` can be a direct way to do what developer want.
