### PR TITLE
Black magic

### DIFF
--- a/lib/kptydevice.h
+++ b/lib/kptydevice.h
@@ -250,9 +250,8 @@ public:
             tail += bytes;
         } else {
             buffers.last().resize(tail);
-            QByteArray tmp;
-            tmp.resize(qMax(CHUNKSIZE, bytes));
-            ptr = tmp.data();
+            char *tmp = new char[qMax(CHUNKSIZE, bytes)];
+            ptr = tmp;
             buffers << tmp;
             tail = bytes;
         }


### PR DESCRIPTION
This needs tests, because
1. It can cause memory leaks (no idea if there is anything that frees memory). In a perfect world smart pointer should be used.
2. There is no guarantee that `ptr = buffers.last().data() + tail` is okay (I guess its unsafe)

The previous code created local variable QByteArray, stored a pointer to its data outside of its scope (!!) and then returned that pointer out of the function(!!!!).