### PR TITLE
 Screen.h: boolean modes

### DIFF
--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -637,8 +637,8 @@ private:
     int _bottomMargin;
 
     // states ----------------
-    int currentModes[MODES_SCREEN];
-    int savedModes[MODES_SCREEN];
+    bool currentModes[MODES_SCREEN];
+    bool savedModes[MODES_SCREEN];
 
     // ----------------------------
 


### PR DESCRIPTION
These are used only as bool everywhere in the code. Changed this just because I can :)