### PR TITLE
WIP: Fix running tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 script:
-  - "curl -s https://raw.githubusercontent.com/mikkeloscar/arch-travis/master/arch-travis.sh | bash"
+  - "curl -s https://raw.githubusercontent.com/bartoszek/arch-travis/signle-line-script/arch-travis.sh | bash"
 
 arch:
   repos:


### PR DESCRIPTION
Apparently the latest arch-travis no longer accepts a string in
`arch.script`:
```
-e:1:in `<main>': undefined method `join' for nil:NilClass (NoMethodError)
-e:1:in `<main>': undefined method `join' for "bash ./.ci/build.sh":String (NoMethodError)
-e:1:in `<main>': undefined method `join' for nil:NilClass (NoMethodError)
```
Use a list to work around it.

Ref: https://github.com/mikkeloscar/arch-travis/issues/60
Closes: https://github.com/lxqt/qtermwidget/issues/295