### PR TITLE
Use QStaticText to boost text rendering performance

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -859,10 +859,7 @@ void TerminalDisplay::drawCharacters(QPainter& painter,
         if (_bidiEnabled) {
             painter.drawText(rect.x(), rect.y() + _fontAscent + _lineSpacing, QString::fromStdWString(text));
         } else {
-            QRect drawRect(rect.topLeft(), rect.size());
-            drawRect.setHeight(rect.height() + _drawTextAdditionHeight);
-
-            QString draw_text_str = LTR_OVERRIDE_CHAR + QString::fromStdWString(text);
+            QString draw_text_str = QString::fromStdWString(text);
             uint32_t draw_text_flags = 0;
             if (useBold) draw_text_flags |= (1 << 0);
             if (useUnderline) draw_text_flags |= (1 << 1);
@@ -876,10 +873,15 @@ void TerminalDisplay::drawCharacters(QPainter& painter,
             if (!staticText) {
                 staticText = new QStaticText(draw_text_str);
                 staticText->setTextFormat(Qt::PlainText);
+                staticText->prepare(QTransform(), font);
                 _staticTextCache.insert(static_text_key, staticText);
             }
 
-            // painter.drawText(drawRect, Qt::AlignBottom, LTR_OVERRIDE_CHAR + QString::fromStdWString(text));
+#if 0
+            QRect drawRect(rect.topLeft(), rect.size());
+            drawRect.setHeight(rect.height() + _drawTextAdditionHeight);
+            painter.drawText(drawRect, Qt::AlignBottom, LTR_OVERRIDE_CHAR + QString::fromStdWString(text));
+#endif
             painter.drawStaticText(rect.topLeft(), *staticText);
         }
     }

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -828,10 +828,11 @@ void TerminalDisplay::drawCharacters(QPainter& painter,
          || font.strikeOut() != useStrikeOut
          || font.overline() != useOverline) {
        font.setBold(useBold);
-       font.setUnderline(useUnderline);
+       // FIXME: QStaticText have some problem with underline, strikeline and overline... see below
+       // font.setUnderline(useUnderline);
        font.setItalic(useItalic);
-       font.setStrikeOut(useStrikeOut);
-       font.setOverline(useOverline);
+       // font.setStrikeOut(useStrikeOut);
+       // font.setOverline(useOverline);
        painter.setFont(font);
     }
 
@@ -862,10 +863,10 @@ void TerminalDisplay::drawCharacters(QPainter& painter,
             QString draw_text_str = QString::fromStdWString(text);
             uint32_t draw_text_flags = 0;
             if (useBold) draw_text_flags |= (1 << 0);
-            if (useUnderline) draw_text_flags |= (1 << 1);
+            // if (useUnderline) draw_text_flags |= (1 << 1);
             if (useItalic) draw_text_flags |= (1 << 2);
-            if (useStrikeOut) draw_text_flags |= (1 << 3);
-            if (useOverline) draw_text_flags |= (1 << 4);
+            // if (useStrikeOut) draw_text_flags |= (1 << 3);
+            // if (useOverline) draw_text_flags |= (1 << 4);
 
             QPair<uint32_t, QString> static_text_key(draw_text_flags, draw_text_str);
 
@@ -883,6 +884,14 @@ void TerminalDisplay::drawCharacters(QPainter& painter,
             painter.drawText(drawRect, Qt::AlignBottom, LTR_OVERRIDE_CHAR + QString::fromStdWString(text));
 #endif
             painter.drawStaticText(rect.topLeft(), *staticText);
+
+            // FIXME: see previous comments
+            if (useUnderline)
+                painter.drawLine(QLineF(rect.left(), rect.bottom() - 0.5, rect.right(), rect.bottom() - 0.5));
+            if (useStrikeOut)
+                painter.drawLine(QLineF(rect.left(), (rect.top() + rect.bottom()) / 2.0, rect.right(), (rect.top() + rect.bottom()) / 2.0));
+            if (useOverline)
+                painter.drawLine(QLineF(rect.left(), rect.top() + 0.5, rect.right(), rect.top() + 0.5));
         }
     }
 }

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -875,6 +875,7 @@ void TerminalDisplay::drawCharacters(QPainter& painter,
             QStaticText *staticText = _staticTextCache.object(static_text_key);
             if (!staticText) {
                 staticText = new QStaticText(draw_text_str);
+                staticText->setTextFormat(Qt::PlainText);
                 _staticTextCache.insert(static_text_key, staticText);
             }
 

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -882,8 +882,14 @@ void TerminalDisplay::drawCharacters(QPainter& painter,
             QRect drawRect(rect.topLeft(), rect.size());
             drawRect.setHeight(rect.height() + _drawTextAdditionHeight);
             painter.drawText(drawRect, Qt::AlignBottom, LTR_OVERRIDE_CHAR + QString::fromStdWString(text));
+#else
+            // painter.drawStaticText(rect.topLeft(), *staticText);
+            painter.drawStaticText(
+                QPointF(
+                    rect.left(),
+                    rect.top() - (staticText->size().height() - rect.height()) * 4 / 5),  // align baseline for fallback font (80% of height)
+                *staticText);
 #endif
-            painter.drawStaticText(rect.topLeft(), *staticText);
 
             // FIXME: see previous comments
             if (useUnderline)
@@ -1294,7 +1300,6 @@ void TerminalDisplay::updateImage()
   if (!_hasBlinker && _blinkTimer->isActive()) { _blinkTimer->stop(); _blinking = false; }
   delete[] dirtyMask;
   delete[] disstrU;
-
 }
 
 void TerminalDisplay::showResizeNotification()

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -25,6 +25,9 @@
 #include <QColor>
 #include <QPointer>
 #include <QWidget>
+#include <QStaticText>
+#include <QCache>
+#include <QPair>
 
 // Konsole
 #include "Filter.h"
@@ -826,6 +829,8 @@ private:
 
     int _leftBaseMargin;
     int _topBaseMargin;
+
+    QCache<QPair<uint32_t, QString>, QStaticText> _staticTextCache;
 
 public:
     static void setTransparencyEnabled(bool enable)


### PR DESCRIPTION
Currently, text rendering in qtermwidget is feature-rich (unicode, font ligatures, etc.) but not fast enough. This change uses `QStaticText` to cache layout information of each text fragment. Since that for typical terminal use case (consider scolling in vim), same text fragments are being rendered repeatedly, caching layout information can save a lot of time. Also, this change does not break font ligatures or unicode.

You can easily notice the performance improvement using vim or some other similar terminal applications.

I've been using my terminal with this change as my primary terminal for several weeks now and haven't found any issues.

However there's some changes in the code that may require more discussion:

- The size of the cache is now set to a fixed value (4096)
- `QStaticText` doesn't work well with underline and strikeout, so I draw them individually instead
- `drawStaticText` starts in the top-left corner instead of the baseline, so I didn't find any reliable way to correctly align characters from different fonts (fallback fonts, especially those CJK characters). I now assumes that the height from top to baseline of fallback fonts is 80% of the its total height.
- I removed `LTR_OVERRIDE_CHAR` because, I don't know, it somewhat make the behavior of `QStaticText` incorrect (alignment issue). I don't write RTL text so unfortunately I cannot verify if it breaks anything. 