### PR TITLE
Fix SearchBar light text over white background with dark themes

### DIFF
--- a/lib/SearchBar.cpp
+++ b/lib/SearchBar.cpp
@@ -113,8 +113,6 @@ void SearchBar::keyReleaseEvent(QKeyEvent* keyEvent)
 
 void SearchBar::clearBackgroundColor()
 {
-    QPalette p;
-    p.setColor(QPalette::Base, Qt::white);
-    widget.searchTextEdit->setPalette(p);
+    widget.searchTextEdit->setPalette(QWidget::window()->palette());
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the title above. You       --->
<!--- should not delete relevant sections and/or questions in your report  --->
Currently `SearchBar::clearBackgroundColor()` forces the search bar background to white, which works fine with a light theme. But if you use a dark theme with light font color it can't be readable.

![Captura de pantalla_2019-12-04_22-43-13](https://user-images.githubusercontent.com/12565871/70237942-82664700-1768-11ea-97fc-d1737107c5b1.png)


<!--- BEFORE FILLING OUT THIS REPORT FORM:                                 --->
<!--- Dear users of stable and LTS (long term service) distributions:      --->
<!--- Please do NOT file bugs against old (dead) versions but use your     --->
<!--- distribution bugtracker instead. This is esp. true for Ubuntu LTS.   --->

##### Expected Behavior
<!--- If you're describing a bug, tell us what should happen                -->
<!--- If you're suggesting a change/improvement, tell us how it should work -->
The search bar background should maintain the theme's background

![image](https://user-images.githubusercontent.com/12565871/70239114-face0780-176a-11ea-88e2-49feea0dbe14.png)


##### Current Behavior
<!--- If describing a bug, tell us what happens instead of the expected    --->
<!--- behaviour. If suggesting a change/improvement, explain the difference -->
<!--- from current behavior (a screenshot might help)                      --->
The search bar is forced to change its background color to white, overriding the theme's one

##### Possible Solution
I'm not a Qt developer but I've found that instead of using `p.setColor(QPalette::Base, Qt::white)` palette `QWidget::window()->palette()` restores the widget background using the theme's colors.
<!--- Not obligatory, but suggest a fix/reason for the bug,                --->
<!--- or ideas how to implement the addition or change                     --->

##### Steps to Reproduce (for bugs)
<!--- Provide a link to a live example, or an unambiguous set of steps to  --->
<!--- reproduce this bug. Include code to reproduce, if relevant           --->
1. Change Qt theme to a dark one
2. Open Qterminal
3. Open search bar (Ctrl + Shift + F)
4. Write anything that matches a string in the console

##### Context
<!--- How has this issue affected you? What are you trying to accomplish?  --->
<!--- Providing context helps us come up with a solution that is most      --->
<!--- useful in the real world                                             --->
I frequently use the search bar

##### System Information
<!--- Include as many relevant details about the system you experienced    --->
<!--- the bug in                                                           --->
* Distribution & Version: Kali Linux
* Kernel: 5.3.0 amd64
* Qt Version: 5.12.5
* lxqt-build-tools Version: 0.6.0
* Package version: git master
