### PR TITLE
pyqt: also check for sip 5.x path

### DIFF
--- a/pyqt/cmake/FindPyQt5.py
+++ b/pyqt/cmake/FindPyQt5.py
@@ -5,6 +5,7 @@
 import PyQt5.Qt
 import sys
 import os.path
+import site
 
 print("pyqt_version:%06.0x" % PyQt5.Qt.PYQT_VERSION)
 print("pyqt_version_str:%s" % PyQt5.Qt.PYQT_VERSION_STR)
@@ -21,8 +22,18 @@ for item in PyQt5.Qt.PYQT_CONFIGURATION["sip_flags"].split(' '):
         in_t = False
 print("pyqt_version_tag:%s" % pyqt_version_tag)
 
-# FIXME This next line is just a little bit too crude.
-pyqt_sip_dir = os.path.join(sys.prefix, "share", "sip", "PyQt5")
+# FIXME Is there a way to query the path from sip instead of hardcoding it?
+candidates = [
+    os.path.join(site.getsitepackages()[0], "PyQt5", "bindings"),   # sip 5.x
+    os.path.join(sys.prefix, "share", "sip", "PyQt5"),              # sip 4.x
+]
+try:
+    pyqt_sip_dir = next(
+        p for p in candidates
+        if os.path.exists(os.path.join(p, "QtCore", "QtCoremod.sip"))
+    )
+except StopIteration:
+    raise RuntimeError("Cannot find QtCore/QtCoremod.sip from candidates: " + repr(candidates))
 print("pyqt_sip_dir:%s" % pyqt_sip_dir)
 
 print("pyqt_sip_flags:%s" % PyQt5.Qt.PYQT_CONFIGURATION["sip_flags"])


### PR DESCRIPTION
See: https://www.archlinux.org/packages/extra/x86_64/python-pyqt5/files/

Tested with: Arch Linux, python-pyqt5 5.14.1-1, qt5-base 5.14.0-2