### PR TITLE
Fix build with LLVM/clang

### DIFF
--- a/lib/TerminalCharacterDecoder.cpp
+++ b/lib/TerminalCharacterDecoder.cpp
@@ -31,6 +31,8 @@
 // Konsole
 #include "konsole_wcwidth.h"
 
+#include <cwctype>
+
 using namespace Konsole;
 PlainTextDecoder::PlainTextDecoder()
  : _output(nullptr)


### PR DESCRIPTION
Fix error:

```
/usr/bin/clang++  -DCOLORSCHEMES_DIR=\"/usr/share/qtermwidget5/color-schemes\" -DHAVE_POSIX_OPENPT -DHAVE_SYS_TIME_H -DHAVE_UPDWTMPX -DKB_LAYOUT_DIR=\"/usr/share/qtermwidget5/kb-layouts\" -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_FOREACH -DQT_NO_URL_CAST_FROM_STRING -DQT_USE_QSTRINGBUILDER -DQT_WIDGETS_LIB -DTRANSLATIONS_DIR=\"/usr/share/qtermwidget5/translations\" -Dqtermwidget5_EXPORTS -I/builddir/build/BUILD/qtermwidget-0.14.1/build -I/builddir/build/BUILD/qtermwidget-0.14.1 -I/builddir/build/BUILD/qtermwidget-0.14.1/lib -I/builddir/build/BUILD/qtermwidget-0.14.1/build/lib -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtWidgets -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtCore -isystem /usr/lib64/qt5/./mkspecs/linux-clang  -Os -fomit-frame-pointer -g1 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param=ssp-buffer-size=4  -m64 -mtune=generic -flto -fno-exceptions -Wall -Wextra -Wchar-subscripts -Wno-long-long -Wpointer-arith -Wundef -Wformat-security -Wnon-virtual-dtor -Woverloaded-virtual -Wpedantic -Wno-gnu-zero-variadic-macro-arguments -Os -fomit-frame-pointer -g1 -Wstrict-aliasing=2 -pipe -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param=ssp-buffer-size=4  -m64 -mtune=generic -flto -fPIC -fvisibility=hidden -fvisibility-inlines-hidden   -fPIC -std=gnu++14 -o CMakeFiles/qtermwidget5.dir/lib/TerminalCharacterDecoder.cpp.o -c /builddir/build/BUILD/qtermwidget-0.14.1/lib/TerminalCharacterDecoder.cpp
make[2]: Leaving directory '/builddir/build/BUILD/qtermwidget-0.14.1/build'
BUILDSTDERR: /builddir/build/BUILD/qtermwidget-0.14.1/lib/TerminalCharacterDecoder.cpp:205:18: error: no member named 'iswspace' in namespace 'std'; did you mean 'isspace'?
BUILDSTDERR:         if (std::iswspace(ch))
BUILDSTDERR:             ~~~~~^~~~~~~~
BUILDSTDERR:                  isspace
BUILDSTDERR: /usr/bin/../lib64/gcc/x86_64-openmandriva-linux-gnu/10.0.0/../../../../include/c++/10.0.0/cctype:72:11: note: 'isspace' declared here
BUILDSTDERR:   using ::isspace;
BUILDSTDERR:           ^
BUILDSTDERR: 1 error generated.
BUILDSTDERR: make[2]: *** [CMakeFiles/qtermwidget5.dir/build.make:442: CMakeFiles/qtermwidget5.dir/lib/TerminalCharacterDecoder.cpp.o] Error 1
BUILDSTDERR: make[2]: *** Waiting for unfinished jobs....
```