### PR TITLE
Explicitly mark exported classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ target_compile_definitions(${QTERMWIDGET_LIBRARY_NAME}
 
 generate_export_header(${QTERMWIDGET_LIBRARY_NAME}
     EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/lib/qtermwidget_export.h"
-    EXPORT_MACRO_NAME QTERMWIDGET_EXPORT
+    BASE_NAME QTERMWIDGET
 )
 
 target_include_directories(${QTERMWIDGET_LIBRARY_NAME}

--- a/lib/Emulation.h
+++ b/lib/Emulation.h
@@ -33,9 +33,7 @@
 #include <QTextStream>
 #include <QTimer>
 
-// Konsole
-//#include "konsole_export.h"
-#define KONSOLEPRIVATE_EXPORT
+#include "qtermwidget_export.h"
 
 namespace Konsole
 {
@@ -120,7 +118,7 @@ enum
  * how long the emulation has been active/idle for and also respond to
  * a 'bell' event in different ways.
  */
-class KONSOLEPRIVATE_EXPORT Emulation : public QObject
+class QTERMWIDGET_EXPORT Emulation : public QObject
 {
 Q_OBJECT
 

--- a/lib/Filter.h
+++ b/lib/Filter.h
@@ -29,6 +29,7 @@
 #include <QRegExp>
 
 // Local
+#include "qtermwidget_export.h"
 
 namespace Konsole
 {
@@ -54,7 +55,7 @@ class Character;
  * When processing the text they should create instances of Filter::HotSpot subclasses for sections of interest
  * and add them to the filter's list of hotspots using addHotSpot()
  */
-class Filter : public QObject
+class QTERMWIDGET_EXPORT Filter : public QObject
 {
 public:
     /**
@@ -183,7 +184,7 @@ private:
  * Subclasses can reimplement newHotSpot() to return custom hotspot types when matches for the regular expression
  * are found.
  */
-class RegExpFilter : public Filter
+class QTERMWIDGET_EXPORT RegExpFilter : public Filter
 {
 public:
     /**
@@ -240,7 +241,7 @@ private:
 class FilterObject;
 
 /** A filter which matches URLs in blocks of text */
-class UrlFilter : public RegExpFilter
+class QTERMWIDGET_EXPORT UrlFilter : public RegExpFilter
 {
     Q_OBJECT
 public:
@@ -292,7 +293,7 @@ signals:
     void activated(const QUrl& url, bool fromContextMenu);
 };
 
-class FilterObject : public QObject
+class QTERMWIDGET_NO_EXPORT FilterObject : public QObject
 {
     Q_OBJECT
 public:
@@ -324,7 +325,7 @@ signals:
  * The hotSpots() and hotSpotsAtLine() method return all of the hotspots in the text and on
  * a given line respectively.
  */
-class FilterChain : protected QList<Filter*>
+class QTERMWIDGET_EXPORT FilterChain : protected QList<Filter*>
 {
 public:
     virtual ~FilterChain();
@@ -358,7 +359,7 @@ public:
 };
 
 /** A filter chain which processes character images from terminal displays */
-class TerminalImageFilterChain : public FilterChain
+class QTERMWIDGET_NO_EXPORT TerminalImageFilterChain : public FilterChain
 {
 public:
     TerminalImageFilterChain();


### PR DESCRIPTION
Replace EXPORT_MACRO_NAME by BASE_NAME. It serves all macros, not only the
EXPORT ones.