### PR TITLE
Another NetBSD build fix

### DIFF
--- a/lib/kpty.cpp
+++ b/lib/kpty.cpp
@@ -32,9 +32,15 @@
 #define HAVE_LIBUTIL_H
 #endif
 
-#if defined(__OpenBSD__) || defined(__NetBSD__)
+#if defined(__OpenBSD__)
 #define HAVE_LOGIN
 #define HAVE_UTIL_H
+#endif
+
+#if defined(__NetBSD__)
+#define HAVE_LOGIN
+#define HAVE_UTIL_H
+#define HAVE_OPENPTY
 #endif
 
 #if defined(__APPLE__)


### PR DESCRIPTION
Add a HAVE_OPENPTY definition, and move NetBSD definitions into their own block, for clarity.