### PR TITLE
Allow QTermWidget access to TerminalDisplay::setBoldIntense

### DIFF
--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -769,3 +769,8 @@ void QTermWidget::setDrawLineChars(bool drawLineChars)
 {
     m_impl->m_terminalDisplay->setDrawLineChars(drawLineChars);
 }
+
+void QTermWidget::setBoldIntense(bool boldIntense)
+{
+    m_impl->m_terminalDisplay->setBoldIntense(boldIntense);
+}

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -233,6 +233,8 @@ public:
     int getMargin() const;
 
     void setDrawLineChars(bool drawLineChars);
+
+    void setBoldIntense(bool boldIntense);
 signals:
     void finished();
     void copyAvailable(bool);


### PR DESCRIPTION
This is in preparation of an attempt to implement lxqt/qterminal#40