### PR TITLE
Fix ColorEntry copy operator

### DIFF
--- a/lib/CharacterColor.h
+++ b/lib/CharacterColor.h
@@ -81,11 +81,12 @@ public:
   /**
    * Sets the color, transparency and boldness of this color to those of @p rhs.
    */
-  void operator=(const ColorEntry& rhs)
+  ColorEntry& operator=(const ColorEntry& rhs)
   {
        color = rhs.color;
        transparent = rhs.transparent;
        fontWeight = rhs.fontWeight;
+       return *this;
   }
 
   /** The color value of this entry for display. */


### PR DESCRIPTION
A copy operator should not return void.