### PR TITLE
Remove user declared copy assignment

### DIFF
--- a/lib/CharacterColor.h
+++ b/lib/CharacterColor.h
@@ -78,17 +78,6 @@ public:
    */
   ColorEntry() : transparent(false), fontWeight(UseCurrentFormat) {}
 
-  /**
-   * Sets the color, transparency and boldness of this color to those of @p rhs.
-   */
-  ColorEntry& operator=(const ColorEntry& rhs)
-  {
-       color = rhs.color;
-       transparent = rhs.transparent;
-       fontWeight = rhs.fontWeight;
-       return *this;
-  }
-
   /** The color value of this entry for display. */
   QColor color;
 


### PR DESCRIPTION
The implicit definition of a copy constructor as defaulted is deprecated if
the class has a user-declared copy assignment operator or a user-declared
destructor.
In this case the user-declared copy assignment is equal to the
default-generated. Deleting and just use the default generated seems the
best option.