### PR TITLE
Fix building when utempter is enabled

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -2,5 +2,9 @@ set -ex
 
 mkdir build
 cd build
-cmake -DBUILD_EXAMPLE=ON -DQTERMWIDGET_BUILD_PYTHON_BINDING=ON ..
+cmake \
+    -DBUILD_EXAMPLE=ON \
+    -DQTERMWIDGET_BUILD_PYTHON_BINDING=ON \
+    -DQTERMWIDGET_USE_UTEMPTER=ON \
+    ..
 make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(CheckIncludeFile)
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 option(BUILD_EXAMPLE "Build example application. Default OFF." OFF)
-option(QTERMWIDGET_USE_UTEMPTER "Uses the libutempter library. Mainly for FreeBSD" OFF)
+option(QTERMWIDGET_USE_UTEMPTER "Uses the libutempter library." OFF)
 option(QTERMWIDGET_BUILD_PYTHON_BINDING "Build python binding" OFF)
 option(USE_UTF8PROC "Use libutf8proc for better Unicode support. Default OFF" OFF)
 
@@ -172,7 +172,8 @@ if (QTERMWIDGET_USE_UTEMPTER)
         target_compile_definitions(${QTERMWIDGET_LIBRARY_NAME} PRIVATE
                 "HAVE_UTEMPTER"
         )
-        target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} ulog)
+        find_library(UTEMPTER_LIB NAMES utempter ulog REQUIRED)
+        target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} ${UTEMPTER_LIB})
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(CheckIncludeFile)
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 option(BUILD_EXAMPLE "Build example application. Default OFF." OFF)
-option(QTERMWIDGET_USE_UTEMPTER "Uses the libutempter library." OFF)
+option(QTERMWIDGET_USE_UTEMPTER "Uses libutempter on Linux or libulog on FreeBSD for login records." OFF)
 option(QTERMWIDGET_BUILD_PYTHON_BINDING "Build python binding" OFF)
 option(USE_UTF8PROC "Use libutf8proc for better Unicode support. Default OFF" OFF)
 


### PR DESCRIPTION
And test it with CI to make sure it will not break in the future.

Looks like libulog.so is provided by FreeBSD and libutempter.so is
provided on Linux [1].

Closes https://github.com/lxqt/qtermwidget/issues/351.

[1] https://reviews.freebsd.org/D7989?id=20568