### PR TITLE
Check for successful ioctl() calls by testing that the call did not return -1

### DIFF
--- a/lib/kpty.cpp
+++ b/lib/kpty.cpp
@@ -265,7 +265,7 @@ bool KPty::open()
             d->ttyName = ptsn;
 #else
     int ptyno;
-    if (!ioctl(d->masterFd, TIOCGPTN, &ptyno)) {
+    if (ioctl(d->masterFd, TIOCGPTN, &ptyno) != -1) {
         d->ttyName = QByteArray("/dev/pts/") + QByteArray::number(ptyno);
 #endif
 #ifdef HAVE_GRANTPT
@@ -296,7 +296,7 @@ bool KPty::open()
                  * and we need to get another one.
                  */
                 int pgrp_rtn;
-                if (ioctl(d->masterFd, TIOCGPGRP, &pgrp_rtn) == 0 || errno != EIO) {
+                if (ioctl(d->masterFd, TIOCGPGRP, &pgrp_rtn) != -1 || errno != EIO) {
                     ::close(d->masterFd);
                     d->masterFd = -1;
                     continue;
@@ -398,7 +398,7 @@ bool KPty::open(int fd)
         d->ttyName = ptsn;
 # else
     int ptyno;
-    if (!ioctl(fd, TIOCGPTN, &ptyno)) {
+    if (ioctl(fd, TIOCGPTN, &ptyno) != -1) {
         const size_t sz = 32;
         char buf[sz];
         const size_t r = snprintf(buf, sz, "/dev/pts/%d", ptyno);
@@ -690,7 +690,7 @@ bool KPty::setWinSize(int lines, int columns)
     memset(&winSize, 0, sizeof(winSize));
     winSize.ws_row = (unsigned short)lines;
     winSize.ws_col = (unsigned short)columns;
-    return ioctl(d->masterFd, TIOCSWINSZ, (char *)&winSize) == 0;
+    return ioctl(d->masterFd, TIOCSWINSZ, (char *)&winSize) != -1;
 }
 
 bool KPty::setEcho(bool echo)

--- a/lib/kptydevice.cpp
+++ b/lib/kptydevice.cpp
@@ -90,7 +90,7 @@ bool KPtyDevicePrivate::_k_canRead()
 #else
     int available;
 #endif
-    if (!::ioctl(q->masterFd(), PTY_BYTES_AVAILABLE, (char *) &available)) {
+    if (::ioctl(q->masterFd(), PTY_BYTES_AVAILABLE, (char *) &available) != -1) {
 #ifdef Q_OS_SOLARIS
         // A Pty is a STREAMS module, and those can be activated
         // with 0 bytes available. This happens either when ^C is


### PR DESCRIPTION
There is no reason for a successful call to return 0.

Tested on QNX 7.1 and Ubuntu 20.04