### PR TITLE
Delete copy constructor and assignment operator

### DIFF
--- a/lib/kpty.h
+++ b/lib/kpty.h
@@ -50,6 +50,9 @@ public:
     */
     ~KPty();
 
+    KPty(const KPty &) = delete;
+    KPty &operator=(const KPty &) = delete;
+
     /**
      * Create a pty master/slave pair.
      *


### PR DESCRIPTION
They should not be used. Using them will make the app crash.