### PR TITLE
cmake: Fix find_package() developer warning

### DIFF
--- a/cmake/FindUtf8Proc.cmake
+++ b/cmake/FindUtf8Proc.cmake
@@ -47,11 +47,12 @@ find_library(
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(
-    UTF8PROC
+    Utf8Proc
+    FOUND_VAR Utf8Proc_FOUND
     REQUIRED_VARS UTF8PROC_LIBRARY UTF8PROC_INCLUDE_DIR
 )
 
-if(UTF8PROC_FOUND)
+if(Utf8Proc_FOUND)
   set( UTF8PROC_LIBRARIES ${UTF8PROC_LIBRARY} )
   set( UTF8PROC_INCLUDE_DIRS ${UTF8PROC_INCLUDE_DIR} )
 endif()


### PR DESCRIPTION
Make Utf8Proc_FOUND match the name of the calling package (Utf8Proc).
From CMake warning:
This can lead to problems in calling code that expects `find_package`
result variables (e.g., `_FOUND`) to follow a certain pattern.