### PR TITLE
Use QProcess::processId()

### DIFF
--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -539,7 +539,7 @@ void Session::refresh()
 
 bool Session::sendSignal(int signal)
 {
-    int result = ::kill(_shellProcess->pid(),signal);
+    int result = ::kill(static_cast<pid_t>(_shellProcess->processId()),signal);
 
      if ( result == 0 )
      {
@@ -928,7 +928,7 @@ int Session::foregroundProcessId() const
 }
 int Session::processId() const
 {
-    return _shellProcess->pid();
+    return static_cast<int>(_shellProcess->processId());
 }
 int Session::getPtySlaveFd() const
 {

--- a/lib/kprocess.cpp
+++ b/lib/kprocess.cpp
@@ -400,13 +400,3 @@ int KProcess::startDetached(const QStringList &argv)
     QString prog = args.takeFirst();
     return startDetached(prog, args);
 }
-
-int KProcess::pid() const
-{
-#ifdef Q_OS_UNIX
-    return (int) QProcess::pid();
-#else
-    return QProcess::pid() ? QProcess::pid()->dwProcessId : 0;
-#endif
-}
-

--- a/lib/kprocess.h
+++ b/lib/kprocess.h
@@ -311,18 +311,6 @@ public:
      */
     static int startDetached(const QStringList &argv);
 
-    /**
-     * Obtain the process' ID as known to the system.
-     *
-     * Unlike with QProcess::pid(), this is a real PID also on Windows.
-     *
-     * This function can be called only while the process is running.
-     * It cannot be applied to detached processes.
-     *
-     * @return the process ID
-     */
-    int pid() const;
-
 protected:
     /**
      * @internal

--- a/lib/kptyprocess.cpp
+++ b/lib/kptyprocess.cpp
@@ -77,7 +77,7 @@ KPtyProcess::~KPtyProcess()
     if (state() != QProcess::NotRunning)
     {
         qWarning() << Q_FUNC_INFO << "the terminal process is still running, trying to stop it by SIGHUP";
-        ::kill(pid(), SIGHUP);
+        ::kill(static_cast<pid_t>(processId()), SIGHUP);
         waitForFinished(300);
         if (state() != QProcess::NotRunning)
             qCritical() << Q_FUNC_INFO << "process didn't stop upon SIGHUP and will be SIGKILL-ed";

--- a/lib/kptyprocess.h
+++ b/lib/kptyprocess.h
@@ -102,7 +102,7 @@ public:
     bool isRunning() const
     {
         bool rval;
-        (pid() > 0) ? rval= true : rval= false;
+        (processId() > 0) ? rval= true : rval= false;
         return rval;
 
     }


### PR DESCRIPTION
KProcess::pid() can be dropped and just use QProcess::processId()