### PR TITLE
Added modes for background image

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -1368,7 +1368,9 @@ void TerminalDisplay::paintEvent( QPaintEvent* pe )
         paint.restore();
     }
     else
+    {
         paint.fillRect(cr, background);
+    }
 
     paint.save();
     paint.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
@@ -1427,8 +1429,10 @@ void TerminalDisplay::paintEvent( QPaintEvent* pe )
         r.moveCenter(cr.center());
         paint.drawPixmap(r.topLeft(), _backgroundImage);
     }
-    else//if (_backgroundMode == None)
+    else //if (_backgroundMode == None)
+    {
         paint.drawPixmap(0, 0, _backgroundImage);
+    }
 
     paint.restore();
   }

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -62,6 +62,13 @@ namespace Konsole
         MoveEndScreenWindow = 2
     };
 
+    enum BackgroundMode {
+        None,
+        Stretch,
+        Zoom,
+        Fit,
+        Center
+    };
 
 extern unsigned short vt100_graphics[32];
 
@@ -105,6 +112,9 @@ public:
 
     /** Sets the background image of the terminal display. */
     void setBackgroundImage(const QString& backgroundImage);
+
+    /** Sets the background image mode of the terminal display. */
+    void setBackgroundMode(BackgroundMode mode);
 
     /**
      * Specifies whether the terminal display has a vertical scroll bar, and if so whether it
@@ -803,9 +813,10 @@ private:
 
     QSize _size;
 
-    QRgb _blendColor;
+    qreal _opacity;
 
     QPixmap _backgroundImage;
+    BackgroundMode _backgroundMode;
 
     // list of filters currently applied to the display.  used for links and
     // search highlight

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -378,6 +378,11 @@ void QTermWidget::setTerminalBackgroundImage(const QString& backgroundImage)
     m_impl->m_terminalDisplay->setBackgroundImage(backgroundImage);
 }
 
+void QTermWidget::setTerminalBackgroundMode(int mode)
+{
+    m_impl->m_terminalDisplay->setBackgroundMode((Konsole::BackgroundMode)mode);
+}
+
 void QTermWidget::setShellProgram(const QString &progname)
 {
     if (!m_impl->m_session)

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -88,6 +88,7 @@ public:
     QFont getTerminalFont();
     void setTerminalOpacity(qreal level);
     void setTerminalBackgroundImage(const QString& backgroundImage);
+    void setTerminalBackgroundMode(int mode);
 
     //environment
     void setEnvironment(const QStringList & environment);


### PR DESCRIPTION
They are "None", "Stretch", "Zoom", "Fit" and "Center".

Some problems are fixed in the code for the following purposes:

  1. The background image isn't limited to translucent terminals.
  2. The background color isn't blended with the background image. Blending is not only ugly but unneeded. Instead, the user can use translucent images as the background.
  3. Image scaling is smooth and antialiasing.

A patch for QTerminal will follow this to use it.