### PR TITLE
Improve "Undecodable sequence" warnings

### DIFF
--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -22,6 +22,7 @@
 
 // Own
 #include "Vt102Emulation.h"
+#include "tools.h"
 
 // XKB
 //#include <config-konsole.h>
@@ -45,6 +46,7 @@
 #include <QEvent>
 #include <QKeyEvent>
 #include <QByteRef>
+#include <QDebug>
 
 // KDE
 //#include <kdebug.h>
@@ -1360,28 +1362,11 @@ char Vt102Emulation::eraseChar() const
       return '\b';
 }
 
-// print contents of the scan buffer
-static void hexdump(wchar_t* s, int len)
-{ int i;
-  for (i = 0; i < len; i++)
-  {
-    if (s[i] == '\\')
-      printf("\\\\");
-    else
-    if ((s[i]) > 32 && s[i] < 127)
-      printf("%c",s[i]);
-    else
-      printf("\\%04x(hex)",s[i]);
-  }
-}
-
 void Vt102Emulation::reportDecodingError()
 {
   if (tokenBufferPos == 0 || ( tokenBufferPos == 1 && (tokenBuffer[0] & 0xff) >= 32) )
     return;
-  printf("Undecodable sequence: ");
-  hexdump(tokenBuffer,tokenBufferPos);
-  printf("\n");
+  qCDebug(qtermwidgetLogger) << "Undecodable sequence:" << QString::fromWCharArray(tokenBuffer, tokenBufferPos);
 }
 
 //#include "Vt102Emulation.moc"

--- a/lib/tools.cpp
+++ b/lib/tools.cpp
@@ -5,6 +5,8 @@
 #include <QtDebug>
 
 
+Q_LOGGING_CATEGORY(qtermwidgetLogger, "qtermwidget", QtWarningMsg)
+
 /*! Helper function to get possible location of layout files.
 By default the KB_LAYOUT_DIR is used (linux/BSD/macports).
 But in some cases (apple bundle) there can be more locations).

--- a/lib/tools.h
+++ b/lib/tools.h
@@ -3,9 +3,12 @@
 
 #include <QString>
 #include <QStringList>
+#include <QLoggingCategory>
 
 QString get_kb_layout_dir();
 void add_custom_color_scheme_dir(const QString& custom_dir);
 const QStringList get_color_schemes_dirs();
+
+Q_DECLARE_LOGGING_CATEGORY(qtermwidgetLogger)
 
 #endif


### PR DESCRIPTION
Using Qt logging utilities instead of printf so that those warnings
can be enabled/disabled. Those warnings are disabled by default. To
enable them, use QT_LOGGING_RULES="qtermwidget.debug=true".

Also improve the formatting. An example warning:
```
Undecodable sequence: "\u001B[22;0;0t"
```
Closes https://github.com/lxqt/qterminal/issues/640
Closes https://github.com/lxqt/qtermwidget/issues/392