### PR TITLE
Update docs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+qtermwidget-0.17.0 / unreleased
+===============================
+  * Drop support for KDE3 color scheme formats. (#367)
+  * Added modes for background image. How background images are drawn is changed and manual reconfiguration is needed. See docs/configuration.md for more details. (#385)
+
 qtermwidget-0.16.1 / 2020-11-14
 ===============================
   * Bumped version to 0.16.1, for a point release of qterminal.

--- a/README.md
+++ b/README.md
@@ -52,15 +52,17 @@ License: public-domain
 
 ### Compiling sources
 
-The only runtime dependency is qtbase ≥ 5.7.1.
+The only runtime dependency is qtbase ≥ 5.12.0.
 Build dependencies are as follows:
-- CMake ≥ 3.0.2 serves as the build system and therefore needs to be present to compile.
--  [lxqt-build-tools](https://github.com/lxqt/lxqt-build-tools/) >= 0.4.0 is also needed for compilation.
--  Git is needed to pull translations and optionally pull latest VCS checkouts.
+- CMake ≥ 3.1.0 serves as the build system and therefore needs to be present to compile.
+- The latest [lxqt-build-tools](https://github.com/lxqt/lxqt-build-tools/) is also needed for compilation.
+- Git is needed to optionally pull latest VCS checkouts.
 
 Code configuration is handled by CMake. CMake variable `CMAKE_INSTALL_PREFIX` will normally have to be set to `/usr`, depending on the way library paths are dealt with on 64bit systems. Variables like `CMAKE_INSTALL_LIBDIR` may have to be set as well.
 
 To build, run `make`. To install, run `make install` which accepts variable `DESTDIR` as usual.
+
+To build PyQt bindings, specify an additional CMake option `QTERMWIDGET_BUILD_PYTHON_BINDING=ON` when building this library.
 
 ### Binary packages
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,12 +4,17 @@ How the background image is drawn has been changed since version 0.17.
 Intuitively, the background image is now drawn above the background color instead of below it.
 Technically, the background image is no longer blended with the background color.
 
-Before migrating the settings, the background image should be converted to a translucent one with the transparency level matching the original terminal transparency.
-For example, if the original terminal transparency of qtermwidget was 25%, the converted image should have transparency 25%.
+Any background image can be used but, of course, it should be chosen so that the terminal text can be easily read on it.
+Since an image may not be totally dark or light, you might want to use a translucent image as the background.
+As a result, the background image is mixed with the background color to improve readability.
+Opaque images can also be converted to translucent ones with a few steps.
+
+A common usage is an effect similiar to previous qtermwidget versions or other terminal emulators.
+To achieve that, you can convert the background image to a translucent one with the transparency level matching the original terminal transparency.
+For example, if the original terminal transparency of qtermwidget was 25% (or 75% in some other terminal emulators), a converted image with transparency 25% will work as usual.
 The conversion can be done via ImageMagick, GraphicsMagick, GIMP or Krita.
 Here is an example command using ImageMagick:
 
     $ convert original_image.jpg -matte -channel A +level 0,25% +channel translucent_image.png
 
-The converted image can be specified as the terminal background image to achieve a similar effect to previous versions.
-Note that you also need to change the terminal transparency to 0% if you do not want to see another window or the desktop below the terminal.
+You may also want to change the terminal transparency to 0% if you do not want to see another window or the desktop below the terminal.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,15 @@
+# Migration for background images
+
+How the background image is drawn has been changed since version 0.17.
+Intuitively, the background image is now drawn above the background color instead of below it.
+Technically, the background image is no longer blended with the background color.
+
+Before migrating the settings, the background image should be converted to a translucent one with the transparency level matching the original terminal transparency.
+For example, if the original terminal transparency of qtermwidget was 25%, the converted image should have transparency 25%.
+The conversion can be done via ImageMagick, GraphicsMagick, GIMP or Krita.
+Here is an example command using ImageMagick:
+
+    $ convert original_image.jpg -matte -channel A +level 0,25% +channel translucent_image.png
+
+The converted image can be specified as the terminal background image to achieve a similar effect to previous versions.
+Note that you also need to change the terminal transparency to 0% if you do not want to see another window or the desktop below the terminal.


### PR DESCRIPTION
* Minimal Qt version is bumped in https://github.com/lxqt/lxqt/issues/1844
* Minimal CMake version is bumped in https://github.com/lxqt/qtermwidget/pull/230
* Closes #402 - confusion around lxqt-build-tools version and PyQt
  builds

@tsujan: I requested a review just as a reminder. This PR is in no hurry. Any time before 0.17 is fine.