### PR TITLE
Quote drag-and-drop filenames

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -3203,10 +3203,10 @@ void TerminalDisplay::dropEvent(QDropEvent* event)
         // without quoting them (this only affects paths with spaces in)
         //urlText = KShell::quoteArg(urlText);
 
-        dropText += urlText;
-
-        if ( i != urls.count()-1 )
-            dropText += QLatin1Char(' ');
+        dropText += QLatin1Char("'");
+        dropText += urlText; 
+        dropText += QLatin1Char("'");
+        dropText += QLatin1Char(" ");
     }
   }
   else


### PR DESCRIPTION
Allows drag-and-drop of files and directories that have spaces in their paths
Closes https://github.com/lxqt/qterminal/issues/474