### PR TITLE
Quote drag-and-drop filenames

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -3203,9 +3203,8 @@ void TerminalDisplay::dropEvent(QDropEvent* event)
         // without quoting them (this only affects paths with spaces in)
         //urlText = KShell::quoteArg(urlText);
 
-        dropText += QLatin1Char('\'');
-        dropText += urlText;
-        dropText += QLatin1Char('\'');
+        QChar q(QLatin1Char('\''));
+        dropText += q + QString(urlText).replace(q, QLatin1String("'\\''")) + q;
         dropText += QLatin1Char(' ');
     }
   }

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -3203,10 +3203,10 @@ void TerminalDisplay::dropEvent(QDropEvent* event)
         // without quoting them (this only affects paths with spaces in)
         //urlText = KShell::quoteArg(urlText);
 
+        dropText += QLatin1Char('\'');
         dropText += urlText;
-
-        if ( i != urls.count()-1 )
-            dropText += QLatin1Char(' ');
+        dropText += QLatin1Char('\'');
+        dropText += QLatin1Char(' ');
     }
   }
   else


### PR DESCRIPTION
Allows drag-and-drop of files and directories that have spaces in their paths
Closes lxqt/qterminal#474