### PR TITLE
Fixed crashes under (Plasma) Wayland on opening tab and splitting

### DIFF
--- a/lib/TerminalCharacterDecoder.cpp
+++ b/lib/TerminalCharacterDecoder.cpp
@@ -79,6 +79,16 @@ void PlainTextDecoder::decodeLine(const Character* const characters, int count, 
         _linePositions << pos;
     }
 
+    // check the real length
+    for (int i = 0 ; i < count ; i++)
+    {
+        if (characters + i == nullptr)
+        {
+            count = i;
+            break;
+        }
+    }
+
     //TODO should we ignore or respect the LINE_WRAPPED line property?
 
     //note:  we build up a QString and send it to the text stream rather writing into the text


### PR DESCRIPTION
With this check, I can't make QTerminal crash by splitting or opening new tabs under Plasma Wayland.

Fixes https://github.com/lxqt/qterminal/issues/806 and fixes https://github.com/lxqt/qterminal/issues/820