### PR TITLE
use QRandomGenerator instead of qrand()

### DIFF
--- a/lib/ColorScheme.cpp
+++ b/lib/ColorScheme.cpp
@@ -31,6 +31,7 @@
 #include <QSettings>
 #include <QDir>
 #include <QRegularExpression>
+#include <QRandomGenerator>
 
 
 // KDE
@@ -175,25 +176,21 @@ void ColorScheme::setColorTableEntry(int index , const ColorEntry& entry)
 
     _table[index] = entry;
 }
-ColorEntry ColorScheme::colorEntry(int index , uint randomSeed) const
+ColorEntry ColorScheme::colorEntry(int index) const
 {
     Q_ASSERT( index >= 0 && index < TABLE_COLORS );
 
-    if ( randomSeed != 0 )
-        qsrand(randomSeed);
-
     ColorEntry entry = colorTable()[index];
 
-    if ( randomSeed != 0 &&
-        _randomTable != nullptr &&
+    if ( _randomTable != nullptr &&
         !_randomTable[index].isNull() )
     {
         const RandomizationRange& range = _randomTable[index];
 
 
-        int hueDifference = range.hue ? (qrand() % range.hue) - range.hue/2 : 0;
-        int saturationDifference = range.saturation ? (qrand() % range.saturation) - range.saturation/2 : 0;
-        int  valueDifference = range.value ? (qrand() % range.value) - range.value/2 : 0;
+        int hueDifference = range.hue ? QRandomGenerator::global()->bounded(range.hue) - range.hue/2 : 0;
+        int saturationDifference = range.saturation ? QRandomGenerator::global()->bounded(range.saturation) - range.saturation/2 : 0;
+        int valueDifference = range.value ? QRandomGenerator::global()->bounded(range.value) - range.value/2 : 0;
 
         QColor& color = entry.color;
 
@@ -206,10 +203,10 @@ ColorEntry ColorScheme::colorEntry(int index , uint randomSeed) const
 
     return entry;
 }
-void ColorScheme::getColorTable(ColorEntry* table , uint randomSeed) const
+void ColorScheme::getColorTable(ColorEntry* table) const
 {
     for ( int i = 0 ; i < TABLE_COLORS ; i++ )
-        table[i] = colorEntry(i,randomSeed);
+        table[i] = colorEntry(i);
 }
 bool ColorScheme::randomizedBackgroundColor() const
 {

--- a/lib/ColorScheme.h
+++ b/lib/ColorScheme.h
@@ -87,14 +87,14 @@ public:
      * @param randomSeed Color schemes may allow certain colors in their
      * palette to be randomized.  The seed is used to pick the random color.
      */
-    void getColorTable(ColorEntry* table, uint randomSeed = 0) const;
+    void getColorTable(ColorEntry* table) const;
 
     /**
      * Retrieves a single color entry from the table.
      *
      * See getColorTable()
      */
-    ColorEntry colorEntry(int index , uint randomSeed = 0) const;
+    ColorEntry colorEntry(int index) const;
 
     /**
      * Convenience method.  Returns the


### PR DESCRIPTION
See also: [QRandomGenerator - doc.qt.io](https://doc.qt.io/qt-6/qrandomgenerator.html)

> Generates one random 32-bit quantity in the range between 0 (inclusive) and highest (exclusive). highest must be positive.

```bash
/home/chungzh/Code/qtermwidget/lib/ColorScheme.cpp: 在成员函数‘Konsole::ColorEntry Konsole::ColorScheme::colorEntry(int, uint) const’中:
/home/chungzh/Code/qtermwidget/lib/ColorScheme.cpp:183:15: 警告：‘void qsrand(uint)’ is deprecated: use QRandomGenerator instead [-Wdeprecated-declarations]
  183 |         qsrand(randomSeed);
      |         ~~~~~~^~~~~~~~~~~~
In file included from /usr/include/qt/QtCore/qchar.h:43,
                 from /usr/include/qt/QtCore/qhash.h:44,
                 from /usr/include/qt/QtCore/QHash:1,
                 from /home/chungzh/Code/qtermwidget/lib/ColorScheme.h:26,
                 from /home/chungzh/Code/qtermwidget/lib/ColorScheme.cpp:23:
/usr/include/qt/QtCore/qglobal.h:1273:81: 附注：在此声明
 1273 | Q_CORE_EXPORT QT_DEPRECATED_VERSION_X_5_15("use QRandomGenerator instead") void qsrand(uint seed);
      |                                                                                 ^~~~~~
/home/chungzh/Code/qtermwidget/lib/ColorScheme.cpp:194:47: 警告：‘int qrand()’ is deprecated: use QRandomGenerator instead [-Wdeprecated-declarations]
  194 |         int hueDifference = range.hue ? (qrand() % range.hue) - range.hue/2 : 0;
      |                                          ~~~~~^~
In file included from /usr/include/qt/QtCore/qchar.h:43,
                 from /usr/include/qt/QtCore/qhash.h:44,
                 from /usr/include/qt/QtCore/QHash:1,
                 from /home/chungzh/Code/qtermwidget/lib/ColorScheme.h:26,
                 from /home/chungzh/Code/qtermwidget/lib/ColorScheme.cpp:23:
/usr/include/qt/QtCore/qglobal.h:1274:80: 附注：在此声明
 1274 | Q_CORE_EXPORT QT_DEPRECATED_VERSION_X_5_15("use QRandomGenerator instead") int qrand();
      |                                                                                ^~~~~
/home/chungzh/Code/qtermwidget/lib/ColorScheme.cpp:195:61: 警告：‘int qrand()’ is deprecated: use QRandomGenerator instead [-Wdeprecated-declarations]
  195 |         int saturationDifference = range.saturation ? (qrand() % range.saturation) - range.saturation/2 : 0;
      |                                                        ~~~~~^~
In file included from /usr/include/qt/QtCore/qchar.h:43,
                 from /usr/include/qt/QtCore/qhash.h:44,
                 from /usr/include/qt/QtCore/QHash:1,
                 from /home/chungzh/Code/qtermwidget/lib/ColorScheme.h:26,
                 from /home/chungzh/Code/qtermwidget/lib/ColorScheme.cpp:23:
/usr/include/qt/QtCore/qglobal.h:1274:80: 附注：在此声明
 1274 | Q_CORE_EXPORT QT_DEPRECATED_VERSION_X_5_15("use QRandomGenerator instead") int qrand();
      |                                                                                ^~~~~
/home/chungzh/Code/qtermwidget/lib/ColorScheme.cpp:196:52: 警告：‘int qrand()’ is deprecated: use QRandomGenerator instead [-Wdeprecated-declarations]
  196 |         int  valueDifference = range.value ? (qrand() % range.value) - range.value/2 : 0;
      |                                               ~~~~~^~
In file included from /usr/include/qt/QtCore/qchar.h:43,
                 from /usr/include/qt/QtCore/qhash.h:44,
                 from /usr/include/qt/QtCore/QHash:1,
                 from /home/chungzh/Code/qtermwidget/lib/ColorScheme.h:26,
                 from /home/chungzh/Code/qtermwidget/lib/ColorScheme.cpp:23:
/usr/include/qt/QtCore/qglobal.h:1274:80: 附注：在此声明
 1274 | Q_CORE_EXPORT QT_DEPRECATED_VERSION_X_5_15("use QRandomGenerator instead") int qrand();
      |                                                                                ^~~~~

```