### PR TITLE
fix: compile time warnings

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2415,7 +2415,7 @@ void TerminalDisplay::mouseReleaseEvent(QMouseEvent* ev)
   }
 }
 
-void TerminalDisplay::getCharacterPosition(const QPoint& widgetPoint,int& line,int& column) const
+void TerminalDisplay::getCharacterPosition(const QPointF& widgetPoint,int& line,int& column) const
 {
     line = (widgetPoint.y()-contentsRect().top()-_topMargin) / _fontHeight;
     if (line < 0)
@@ -2591,7 +2591,7 @@ void TerminalDisplay::wheelEvent( QWheelEvent* ev )
 
     int charLine;
     int charColumn;
-    getCharacterPosition( ev->pos() , charLine , charColumn );
+    getCharacterPosition( ev->position() , charLine , charColumn );
 
     emit mouseSignal( ev->angleDelta().y() > 0 ? 4 : 5,
                       charColumn + 1,

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2573,10 +2573,10 @@ void TerminalDisplay::wheelEvent( QWheelEvent* ev )
         // to get a reasonable scrolling speed, scroll by one line for every 5 degrees
         // of mouse wheel rotation.  Mouse wheels typically move in steps of 15 degrees,
         // giving a scroll of 3 lines
-        int key = ev->delta() > 0 ? Qt::Key_Up : Qt::Key_Down;
+        int key = ev->angleDelta() > 0 ? Qt::Key_Up : Qt::Key_Down;
 
         // QWheelEvent::delta() gives rotation in eighths of a degree
-        int wheelDegrees = ev->delta() / 8;
+        int wheelDegrees = ev->angleDelta() / 8;
         int linesToScroll = abs(wheelDegrees) / 5;
 
         QKeyEvent keyScrollEvent(QEvent::KeyPress,key,Qt::NoModifier);
@@ -2593,7 +2593,7 @@ void TerminalDisplay::wheelEvent( QWheelEvent* ev )
     int charColumn;
     getCharacterPosition( ev->pos() , charLine , charColumn );
 
-    emit mouseSignal( ev->delta() > 0 ? 4 : 5,
+    emit mouseSignal( ev->angleDelta() > 0 ? 4 : 5,
                       charColumn + 1,
                       charLine + 1 +_scrollBar->value() -_scrollBar->maximum() ,
                       0);

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2573,10 +2573,10 @@ void TerminalDisplay::wheelEvent( QWheelEvent* ev )
         // to get a reasonable scrolling speed, scroll by one line for every 5 degrees
         // of mouse wheel rotation.  Mouse wheels typically move in steps of 15 degrees,
         // giving a scroll of 3 lines
-        int key = ev->angleDelta() > 0 ? Qt::Key_Up : Qt::Key_Down;
+        int key = ev->angleDelta().y() > 0 ? Qt::Key_Up : Qt::Key_Down;
 
-        // QWheelEvent::delta() gives rotation in eighths of a degree
-        int wheelDegrees = ev->angleDelta() / 8;
+        // QWheelEvent::angleDelta().y() gives rotation in eighths of a degree
+        int wheelDegrees = ev->angleDelta().y() / 8;
         int linesToScroll = abs(wheelDegrees) / 5;
 
         QKeyEvent keyScrollEvent(QEvent::KeyPress,key,Qt::NoModifier);
@@ -2593,7 +2593,7 @@ void TerminalDisplay::wheelEvent( QWheelEvent* ev )
     int charColumn;
     getCharacterPosition( ev->pos() , charLine , charColumn );
 
-    emit mouseSignal( ev->angleDelta() > 0 ? 4 : 5,
+    emit mouseSignal( ev->angleDelta().y() > 0 ? 4 : 5,
                       charColumn + 1,
                       charLine + 1 +_scrollBar->value() -_scrollBar->maximum() ,
                       0);

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -226,14 +226,14 @@ void TerminalDisplay::fontChange(const QFont&)
   // "Base character width on widest ASCII character. This prevents too wide
   //  characters in the presence of double wide (e.g. Japanese) characters."
   // Get the width from representative normal width characters
-  _fontWidth = qRound((double)fm.width(QLatin1String(REPCHAR))/(double)qstrlen(REPCHAR));
+  _fontWidth = qRound((double)fm.horizontalAdvance(QLatin1String(REPCHAR))/(double)qstrlen(REPCHAR));
 
   _fixedFont = true;
 
-  int fw = fm.width(QLatin1Char(REPCHAR[0]));
+  int fw = fm.horizontalAdvance(QLatin1Char(REPCHAR[0]));
   for(unsigned int i=1; i< qstrlen(REPCHAR); i++)
   {
-    if (fw != fm.width(QLatin1Char(REPCHAR[i])))
+    if (fw != fm.horizontalAdvance(QLatin1Char(REPCHAR[i])))
     {
       _fixedFont = false;
       break;
@@ -1278,7 +1278,7 @@ void TerminalDisplay::showResizeNotification()
      {
          const QString label = tr("Size: XXX x XXX");
         _resizeWidget = new QLabel(label, this);
-        _resizeWidget->setMinimumWidth(_resizeWidget->fontMetrics().width(label));
+        _resizeWidget->setMinimumWidth(_resizeWidget->fontMetrics().horizontalAdvance(label));
         _resizeWidget->setMinimumHeight(_resizeWidget->sizeHint().height());
         _resizeWidget->setAlignment(Qt::AlignCenter);
 
@@ -1623,7 +1623,7 @@ int TerminalDisplay::textWidth(const int startColumn, const int length, const in
   QFontMetrics fm(font());
   int result = 0;
   for (int column = 0; column < length; column++) {
-    result += fm.width(_image[loc(startColumn + column, line)].character);
+    result += fm.horizontalAdvance(_image[loc(startColumn + column, line)].character);
   }
   return result;
 }

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -428,7 +428,7 @@ public:
 
     // maps a point on the widget to the position ( ie. line and column )
     // of the character at that point.
-    void getCharacterPosition(const QPoint& widgetPoint,int& line,int& column) const;
+    void getCharacterPosition(const QPointF& widgetPoint,int& line,int& column) const;
 
     void disableBracketedPasteMode(bool disable) { _disabledBracketedPasteMode = disable; }
     bool bracketedPasteModeIsDisabled() const { return _disabledBracketedPasteMode; }


### PR DESCRIPTION
0a1f0c1
```bash
/home/chungzh/Code/qtermwidget/lib/TerminalDisplay.cpp: 在成员函数‘int Konsole::TerminalDisplay::textWidth(int, int, int) const’中:
/home/chungzh/Code/qtermwidget/lib/TerminalDisplay.cpp:1626:23: 警告：‘int QFontMetrics::width(QChar) const’ is deprecated: Use QFontMetrics::horizontalAdvance [-Wdeprecated-declarations]
 1626 |     result += fm.width(_image[loc(startColumn + column, line)].character);
      |               ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/qt/QtWidgets/qwidget.h:50,
                 from /usr/include/qt/QtWidgets/QWidget:1,
                 from /home/chungzh/Code/qtermwidget/lib/TerminalDisplay.h:27,
                 from /home/chungzh/Code/qtermwidget/lib/TerminalDisplay.cpp:24:
/usr/include/qt/QtGui/qfontmetrics.h:110:9: 附注：在此声明
  110 |     int width(QChar) const;
      |         ^~~~~
```

affa2e6
```bash
/home/chungzh/Code/qtermwidget/lib/TerminalDisplay.cpp:2596:32: 警告：‘int QWheelEvent::delta() const’ is deprecated: Use angleDelta() [-Wdeprecated-declarations]
 2596 |     emit mouseSignal( ev->delta() > 0 ? 4 : 5,
      |                       ~~~~~~~~~^~
In file included from /usr/include/qt/QtGui/QKeyEvent:1,
                 from /home/chungzh/Code/qtermwidget/lib/Emulation.h:30,
                 from /home/chungzh/Code/qtermwidget/lib/qtermwidget.h:25,
                 from /home/chungzh/Code/qtermwidget/lib/TerminalDisplay.h:32,
                 from /home/chungzh/Code/qtermwidget/lib/TerminalDisplay.cpp:24:
/usr/include/qt/QtGui/qevent.h:219:16: 附注：在此声明
  219 |     inline int delta() const  { return qt4D; }
      |                ^~~~~
```

2b237ab
```bash
/home/chungzh/Code/qtermwidget/lib/TerminalDisplay.cpp:2594:34: 警告：‘QPoint QWheelEvent::pos() const’ is deprecated: Use position() [-Wdeprecated-declarations]
 2594 |     getCharacterPosition( ev->pos() , charLine , charColumn );
      |                           ~~~~~~~^~
In file included from /usr/include/qt/QtGui/QKeyEvent:1,
                 from /home/chungzh/Code/qtermwidget/lib/Emulation.h:30,
                 from /home/chungzh/Code/qtermwidget/lib/qtermwidget.h:25,
                 from /home/chungzh/Code/qtermwidget/lib/TerminalDisplay.h:32,
                 from /home/chungzh/Code/qtermwidget/lib/TerminalDisplay.cpp:24:
/usr/include/qt/QtGui/qevent.h:225:19: 附注：在此声明
  225 |     inline QPoint pos() const { return p.toPoint(); }
      |                   ^~~

```