### PR TITLE
Add setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build
 .kdev4
+dist
+QTermWidget.egg-info
+__pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+recursive-include lib *
+recursive-include pyqt *
+recursive-include cmake *
+include CMakeLists.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ recursive-include lib *
 recursive-include pyqt *
 recursive-include cmake *
 include CMakeLists.txt
+include README.md

--- a/QTermWidget/__init__.py
+++ b/QTermWidget/__init__.py
@@ -1,0 +1,1 @@
+from .QTermWidget import QTermWidget

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,63 @@
+from setuptools.command.build_ext import build_ext as build_ext_orig
+from setuptools import setup, Extension
+import pathlib
+import os
+
+
+class CMakeExtension(Extension):
+
+    def __init__(self, name):
+        # don't invoke the original build_ext for this special extension
+        super().__init__(name, sources=[])
+
+
+class build_ext(build_ext_orig):
+
+    def run(self):
+        for ext in self.extensions:
+            self.build_cmake(ext)
+        super().run()
+
+    def build_cmake(self, ext):
+        cwd = pathlib.Path().absolute()
+
+        # these dirs will be created in build_py, so if you don't have
+        # any python sources to bundle, the dirs will be missing
+        build_temp = pathlib.Path(self.build_temp)
+        build_temp.mkdir(parents=True, exist_ok=True)
+        extdir = pathlib.Path(self.get_ext_fullpath(ext.name))
+        extdir.mkdir(parents=True, exist_ok=True)
+
+        # example of cmake args
+        config = "Debug" if self.debug else "Release"
+        cmake_args = [
+            "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + str(extdir.parent.absolute()),
+            "-DCMAKE_BUILD_TYPE=" + config,
+            "-D",
+            "QTERMWIDGET_BUILD_PYTHON_BINDING=ON"
+        ]
+
+        # example of build args
+        build_args = [
+            "--config", config,
+            "--", "-j4"
+        ]
+
+        os.chdir(str(build_temp))
+        self.spawn(["cmake", str(cwd)] + cmake_args)
+        if not self.dry_run:
+            self.spawn(["cmake", "--build", "."] + build_args)
+        # Troubleshooting: if fail on line above then delete all possible
+        # temporary CMake files including "CMakeCache.txt" in top level dir.
+        os.chdir(str(cwd))
+
+
+setup(
+    name="QTermWidget",
+    version='0.1',
+    packages=["QTermWidget"],
+    ext_modules=[CMakeExtension("QTermWidget/*")],
+    cmdclass={
+        "build_ext": build_ext,
+    }
+)


### PR DESCRIPTION
This PR tries to create a Whell for Python. It should close #364. The code was copied from [StackOverflow](https://stackoverflow.com/questions/42585210/extending-setuptools-extension-to-use-cmake-in-setup-py).

**What does work?**
I created a small demo program to test:
```python
from PyQt5.QtWidgets import QApplication
from QTermWidget import QTermWidget
import sys


if __name__ == "__main__":
    app = QApplication(sys.argv)
    term = QTermWidget()
    term.show()
    sys.exit(app.exec())
```

I used the follwing enviroment:
A VM wwith Arch Linux. All needed packages to build are installed. PyQt5 is installed with Pacman. QTermWidget is not installed.

How to build:
```
python setup.py bdist_wheel
pip install ./dist/*.whl
```

The demo program above worked.


**What does not work?**
The package dosen't contain data files such as the color-schemes. I needed to figure out how to copy them from the lib folder into the package and QTermWidget needs to recognize they on this place.

Building from a source package does also not work.
```
python setup.py bdist_wheel
pip install ./dist/QTermWidget-0.1.tar.gz
```

The build and instalation have no problems. But when I try to run I get the following error:
```
ImportError: libqtermwidget5.so.0: cannot open shared object file: No such file or directory
```
libqtermwidget5.so.0 is in the same folder as the rest. It has the same files like the wheel, so I don't know what's the problem here.

**What was not tested?**
I don't know if the Binaries are working on other systems than mine. We may have to take a look at [manylinux](https://opensource.com/article/19/2/manylinux-python-wheels).