### PR TITLE
Do not test PyQt on CI

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -5,12 +5,9 @@ source shared-ci/prepare-archlinux.sh
 # See *depends in https://github.com/archlinuxcn/repo/blob/master/archlinuxcn/qtermwidget-git/PKGBUILD
 pacman -S --noconfirm --needed git cmake lxqt-build-tools-git qt5-tools python-sip4 sip4
 
-# Use older PyQt for now as 5.15.6 does not work with SIP 4
-# https://www.riverbankcomputing.com/pipermail/pyqt/2021-November/044345.html
-pacman -U --noconfirm https://archive.archlinux.org/packages/p/python-pyqt5/python-pyqt5-5.15.5-1-x86_64.pkg.tar.zst
-
+# TODO: re-enable PyQt bindings after switching to sip5
 cmake -B build -S . \
     -DBUILD_EXAMPLE=ON \
-    -DQTERMWIDGET_BUILD_PYTHON_BINDING=ON \
+    -DQTERMWIDGET_BUILD_PYTHON_BINDING=OFF \
     -DQTERMWIDGET_USE_UTEMPTER=ON
 make -C build


### PR DESCRIPTION
On Arch Linux, PyQt5 no longer works with sip4 [1]. The long term plan
is switching to sip5, but let's disable Python bindings for now to avoid
confusing CI failures.

[1] https://github.com/archlinux/svntogit-packages/commit/9f73b4aabafa235823c529e3a37799ce678b776d