### PR TITLE
functional qtermwidget port to qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,21 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Minimum Versions
 set(QT_MINIMUM_VERSION "5.15.0")
+set(QT6_MINIMUM_VERSION "6.1.0")
 set(LXQTBT_MINIMUM_VERSION "0.10.0")
 
-find_package(Qt5Widgets "${QT_MINIMUM_VERSION}" REQUIRED)
-find_package(Qt5LinguistTools "${QT_MINIMUM_VERSION}" REQUIRED)
+find_package(Qt6 COMPONENTS Widgets)
+if (NOT Qt6_FOUND)
+    find_package(Qt5Widgets "${QT_MINIMUM_VERSION}" REQUIRED)
+    find_package(Qt5LinguistTools "${QT_MINIMUM_VERSION}" REQUIRED)
+endif()
+
+if (Qt6_FOUND)
+    find_package(Qt6Widgets "${QT6_MINIMUM_VERSION}" REQUIRED)
+    find_package(Qt6LinguistTools "${QT6_MINIMUM_VERSION}" REQUIRED)
+    find_package(Qt6Core5Compat "${QT6_MINIMUM_VERSION}" REQUIRED)
+endif()
+
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 
 if(USE_UTF8PROC)
@@ -54,8 +65,11 @@ if(APPLE)
     endif()
 endif()
 
-set(QTERMWIDGET_LIBRARY_NAME qtermwidget5)
-
+if (NOT Qt6_FOUND)
+    set(QTERMWIDGET_LIBRARY_NAME qtermwidget5)
+else()
+    set(QTERMWIDGET_LIBRARY_NAME qtermwidget6)
+endif()
 
 # main library
 
@@ -128,9 +142,15 @@ set(QTERMWIDGET_INCLUDE_DIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${QTERMWIDGET_LIBR
 
 CHECK_FUNCTION_EXISTS(updwtmpx HAVE_UPDWTMPX)
 
-qt5_wrap_cpp(MOCS ${HDRS})
-qt5_wrap_ui(UI_SRCS ${UI})
-set(PKG_CONFIG_REQ "Qt5Widgets")
+if (NOT Qt6_FOUND)
+    qt5_wrap_cpp(MOCS ${HDRS})
+    qt5_wrap_ui(UI_SRCS ${UI})
+    set(PKG_CONFIG_REQ "Qt5Widgets")
+else()
+    qt6_wrap_cpp(MOCS ${HDRS})
+    qt6_wrap_ui(UI_SRCS ${UI})
+    set(PKG_CONFIG_REQ "Qt6Widgets")
+endif()
 
 lxqt_translate_ts(QTERMWIDGET_QM
     TRANSLATION_DIR "lib/translations"
@@ -145,7 +165,12 @@ lxqt_translate_ts(QTERMWIDGET_QM
 )
 
 add_library(${QTERMWIDGET_LIBRARY_NAME} SHARED ${SRCS} ${MOCS} ${UI_SRCS} ${QTERMWIDGET_QM})
-target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt5::Widgets)
+if (NOT Qt6_FOUND)
+    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt5::Widgets)
+else()
+    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt6::Widgets)
+    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt6::Core5Compat)
+endif()
 set_target_properties( ${QTERMWIDGET_LIBRARY_NAME} PROPERTIES
                        SOVERSION ${QTERMWIDGET_VERSION_MAJOR}
                        VERSION ${QTERMWIDGET_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option(BUILD_EXAMPLE "Build example application. Default OFF." OFF)
 option(QTERMWIDGET_USE_UTEMPTER "Uses libutempter on Linux or libulog on FreeBSD for login records." OFF)
 option(QTERMWIDGET_BUILD_PYTHON_BINDING "Build python binding" OFF)
 option(USE_UTF8PROC "Use libutf8proc for better Unicode support. Default OFF" OFF)
-
+option(USE_QT5 "Use Qt 5 instead of Qt6 (if available). Default OFF" OFF)
 
 # just change version for releases
 set(QTERMWIDGET_VERSION_MAJOR "1")
@@ -35,16 +35,21 @@ set(QT_MINIMUM_VERSION "5.15.0")
 set(QT6_MINIMUM_VERSION "6.1.0")
 set(LXQTBT_MINIMUM_VERSION "0.10.0")
 
-find_package(Qt6 COMPONENTS Widgets)
-if (NOT Qt6_FOUND)
+if (NOT USE_QT5)
+    find_package(Qt6 COMPONENTS Widgets)
+    if (NOT Qt6_FOUND)
+        find_package(Qt5Widgets "${QT_MINIMUM_VERSION}" REQUIRED)
+        find_package(Qt5LinguistTools "${QT_MINIMUM_VERSION}" REQUIRED)
+    endif()
+
+    if (Qt6_FOUND)
+        find_package(Qt6Widgets "${QT6_MINIMUM_VERSION}" REQUIRED)
+        find_package(Qt6LinguistTools "${QT6_MINIMUM_VERSION}" REQUIRED)
+        find_package(Qt6Core5Compat "${QT6_MINIMUM_VERSION}" REQUIRED)
+    endif()
+else()
     find_package(Qt5Widgets "${QT_MINIMUM_VERSION}" REQUIRED)
     find_package(Qt5LinguistTools "${QT_MINIMUM_VERSION}" REQUIRED)
-endif()
-
-if (Qt6_FOUND)
-    find_package(Qt6Widgets "${QT6_MINIMUM_VERSION}" REQUIRED)
-    find_package(Qt6LinguistTools "${QT6_MINIMUM_VERSION}" REQUIRED)
-    find_package(Qt6Core5Compat "${QT6_MINIMUM_VERSION}" REQUIRED)
 endif()
 
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
@@ -142,14 +147,20 @@ set(QTERMWIDGET_INCLUDE_DIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${QTERMWIDGET_LIBR
 
 CHECK_FUNCTION_EXISTS(updwtmpx HAVE_UPDWTMPX)
 
-if (NOT Qt6_FOUND)
+if (NOT USE_QT5)
+    if (NOT Qt6_FOUND)
+        qt5_wrap_cpp(MOCS ${HDRS})
+        qt5_wrap_ui(UI_SRCS ${UI})
+        set(PKG_CONFIG_REQ "Qt5Widgets")
+    else()
+        qt6_wrap_cpp(MOCS ${HDRS})
+        qt6_wrap_ui(UI_SRCS ${UI})
+        set(PKG_CONFIG_REQ "Qt6Widgets")
+    endif()
+else()
     qt5_wrap_cpp(MOCS ${HDRS})
     qt5_wrap_ui(UI_SRCS ${UI})
     set(PKG_CONFIG_REQ "Qt5Widgets")
-else()
-    qt6_wrap_cpp(MOCS ${HDRS})
-    qt6_wrap_ui(UI_SRCS ${UI})
-    set(PKG_CONFIG_REQ "Qt6Widgets")
 endif()
 
 lxqt_translate_ts(QTERMWIDGET_QM
@@ -165,12 +176,17 @@ lxqt_translate_ts(QTERMWIDGET_QM
 )
 
 add_library(${QTERMWIDGET_LIBRARY_NAME} SHARED ${SRCS} ${MOCS} ${UI_SRCS} ${QTERMWIDGET_QM})
-if (NOT Qt6_FOUND)
-    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt5::Widgets)
+if (NOT USE_QT5)
+    if (NOT Qt6_FOUND)
+        target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt5::Widgets)
+    else()
+        target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt6::Widgets)
+        target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt6::Core5Compat)
+    endif()
 else()
-    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt6::Widgets)
-    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt6::Core5Compat)
+    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt5::Widgets)
 endif()
+
 set_target_properties( ${QTERMWIDGET_LIBRARY_NAME} PROPERTIES
                        SOVERSION ${QTERMWIDGET_VERSION_MAJOR}
                        VERSION ${QTERMWIDGET_VERSION}

--- a/cmake/qtermwidget6-config.cmake.in
+++ b/cmake/qtermwidget6-config.cmake.in
@@ -1,0 +1,20 @@
+# - Find the QTermWidget include and library
+#
+# Typical usage:
+#    find_package(QTermWidget5 REQUIRED)
+#
+#    add_executable(foo main.cpp)
+#    target_link_libraries(foo qtermwidget5)
+
+@PACKAGE_INIT@
+
+if (CMAKE_VERSION VERSION_LESS 3.0.2)
+    message(FATAL_ERROR \"qtermwidget requires at least CMake version 3.0.2\")
+endif()
+
+if (NOT TARGET @QTERMWIDGET_LIBRARY_NAME@)
+    if (POLICY CMP0024)
+        cmake_policy(SET CMP0024 NEW)
+    endif()
+    include("${CMAKE_CURRENT_LIST_DIR}/@QTERMWIDGET_LIBRARY_NAME@-targets.cmake")
+endif()

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -36,12 +36,12 @@ int main(int argc, char *argv[])
     QMenuBar *menuBar = new QMenuBar(mainWindow);
     QMenu *actionsMenu = new QMenu(QStringLiteral("Actions"), menuBar);
     menuBar->addMenu(actionsMenu);
-    /*actionsMenu->addAction(QStringLiteral("Find..."), console, &QTermWidget::toggleShowSearchBar,
-                           QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_F));
+    actionsMenu->addAction(QStringLiteral("Find..."), console, &QTermWidget::toggleShowSearchBar,
+                           QKeySequence(QLatin1String("Ctrl+Shift+F")));
     actionsMenu->addAction(QStringLiteral("Copy"), console, &QTermWidget::copyClipboard,
-                           QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_C));
+                           QKeySequence(QLatin1String("Ctrl+Shift+C")));
     actionsMenu->addAction(QStringLiteral("Paste"), console, &QTermWidget::pasteClipboard,
-                           QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_V));*/
+                           QKeySequence(QLatin1String("Ctrl+Shift+V")));
     actionsMenu->addAction(QStringLiteral("About Qt"), &app, &QApplication::aboutQt);
     mainWindow->setMenuBar(menuBar);
 

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -36,12 +36,12 @@ int main(int argc, char *argv[])
     QMenuBar *menuBar = new QMenuBar(mainWindow);
     QMenu *actionsMenu = new QMenu(QStringLiteral("Actions"), menuBar);
     menuBar->addMenu(actionsMenu);
-    actionsMenu->addAction(QStringLiteral("Find..."), console, &QTermWidget::toggleShowSearchBar,
+    /*actionsMenu->addAction(QStringLiteral("Find..."), console, &QTermWidget::toggleShowSearchBar,
                            QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_F));
     actionsMenu->addAction(QStringLiteral("Copy"), console, &QTermWidget::copyClipboard,
                            QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_C));
     actionsMenu->addAction(QStringLiteral("Paste"), console, &QTermWidget::pasteClipboard,
-                           QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_V));
+                           QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_V));*/
     actionsMenu->addAction(QStringLiteral("About Qt"), &app, &QApplication::aboutQt);
     mainWindow->setMenuBar(menuBar);
 

--- a/lib/Character.h
+++ b/lib/Character.h
@@ -78,7 +78,11 @@ public:
   union
   {
     /** The unicode character value for this character. */
+#if QT_VERSION >= 0x060000
+    char16_t character;
+#else
     wchar_t character;
+#endif
     /**
      * Experimental addition which allows a single Character instance to contain more than
      * one unicode character.

--- a/lib/ColorScheme.cpp
+++ b/lib/ColorScheme.cpp
@@ -32,7 +32,9 @@
 #include <QDir>
 #include <QRegularExpression>
 #include <QRandomGenerator>
-
+#if QT_VERSION >= 0x060000
+#include <QStringView>
+#endif
 
 // KDE
 //#include <KColorScheme>
@@ -364,9 +366,15 @@ void ColorScheme::readColorEntry(QSettings * s , int index)
         if (hexColorPattern.match(colorStr).hasMatch())
         {
             // Parsing is always ok as already matched by the regexp
+#if QT_VERSION >= 0x060000
+            r = QStringView{colorStr}.mid(1, 2).toInt(nullptr, 16);
+            g = QStringView{colorStr}.mid(3, 2).toInt(nullptr, 16);
+            b = QStringView{colorStr}.mid(5, 2).toInt(nullptr, 16);
+#else
             r = colorStr.midRef(1, 2).toInt(nullptr, 16);
             g = colorStr.midRef(3, 2).toInt(nullptr, 16);
             b = colorStr.midRef(5, 2).toInt(nullptr, 16);
+#endif
             ok = true;
         }
     }

--- a/lib/ColorScheme.cpp
+++ b/lib/ColorScheme.cpp
@@ -341,7 +341,11 @@ void ColorScheme::readColorEntry(QSettings * s , int index)
     bool ok = false;
     // XXX: Undocumented(?) QSettings behavior: values with commas are parsed
     // as QStringList and others QString
+#if QT_VERSION >= 0x060000
+    if (colorValue.typeId() == QMetaType::QStringList)
+#else
     if (colorValue.type() == QVariant::StringList)
+#endif
     {
         QStringList rgbList = colorValue.toStringList();
         colorStr = rgbList.join(QLatin1Char(','));

--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -43,6 +43,8 @@
 #include <QThread>
 
 #include <QTime>
+//TODO REMOVE THIS
+#include <QDebug>
 
 // KDE
 //#include <kdebug.h>
@@ -204,7 +206,9 @@ void Emulation::receiveChar(wchar_t c)
 // process application unicode input to terminal
 // this is a trivial scanner
 {
+    qDebug() << "Emulation::receiveChar: character " << c;
   c &= 0xff;
+  qDebug() << "Emulation::receiveChar (after &=): character " << c;
   switch (c)
   {
     case '\b'      : _currentScreen->backspace();                 break;

--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -33,7 +33,12 @@
 #include <QClipboard>
 #include <QHash>
 #include <QKeyEvent>
+#if QT_VERSION >= 0x060000
+#include <QRegularExpression>
+#include <QtCore5Compat/QTextDecoder>
+#else
 #include <QRegExp>
+#endif
 #include <QTextStream>
 #include <QThread>
 

--- a/lib/Emulation.h
+++ b/lib/Emulation.h
@@ -29,7 +29,11 @@
 // Qt
 #include <QKeyEvent>
 //#include <QPointer>
+#if QT_VERSION >= 0x060000
+#include <QtCore5Compat/QTextCodec>
+#else
 #include <QTextCodec>
+#endif
 #include <QTextStream>
 #include <QTimer>
 

--- a/lib/Filter.h
+++ b/lib/Filter.h
@@ -26,7 +26,11 @@
 #include <QObject>
 #include <QStringList>
 #include <QHash>
+#if QT_VERSION >= 0x060000
+#include <QtCore5Compat/QRegExp>
+#else
 #include <QRegExp>
+#endif
 
 // Local
 #include "qtermwidget_export.h"

--- a/lib/HistorySearch.cpp
+++ b/lib/HistorySearch.cpp
@@ -24,7 +24,7 @@
 #include "Emulation.h"
 #include "HistorySearch.h"
 
-HistorySearch::HistorySearch(EmulationPtr emulation, const QRegExp& regExp,
+HistorySearch::HistorySearch(EmulationPtr emulation, const RegExp& regExp,
         bool forwards, int startColumn, int startLine,
         QObject* parent) :
 QObject(parent),
@@ -41,7 +41,11 @@ HistorySearch::~HistorySearch() {
 void HistorySearch::search() {
     bool found = false;
 
+#if QT_VERSION >= 0x060000
+    if( ! m_regExp.isValid())
+#else
     if (! m_regExp.isEmpty())
+#endif
     {
         if (m_forwards) {
             found = search(m_startColumn, m_startLine, -1, m_emulation->lineCount()) || search(0, 0, m_startColumn, m_startLine);
@@ -119,7 +123,12 @@ bool HistorySearch::search(int startColumn, int startLine, int endColumn, int en
 
         if (matchStart > -1)
         {
+#if QT_VERSION >= 0x060000
+            auto match = m_regExp.match(string);
+            int matchEnd = matchStart + match.capturedLength() - 1;
+#else
             int matchEnd = matchStart + m_regExp.matchedLength() - 1;
+#endif
             qDebug() << "Found in string from" << matchStart << "to" << matchEnd;
 
             // Translate startPos and endPos to startColum, startLine, endColumn and endLine in history.

--- a/lib/HistorySearch.h
+++ b/lib/HistorySearch.h
@@ -29,16 +29,25 @@
 #include "Emulation.h"
 #include "TerminalCharacterDecoder.h"
 
+#if QT_VERSION >= 0x06000
+#include <QRegularExpression>
+#include <QtCore5Compat/QRegExp>
+#endif
+
 using namespace Konsole;
 
 typedef QPointer<Emulation> EmulationPtr;
-
+#if QT_VERSION >= 0x06000
+typedef QRegularExpression RegExp;
+#else
+typedef QRegExp RegExp;
+#endif
 class HistorySearch : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit HistorySearch(EmulationPtr emulation, const QRegExp& regExp, bool forwards,
+    explicit HistorySearch(EmulationPtr emulation, const RegExp& regExp, bool forwards,
                            int startColumn, int startLine, QObject* parent);
 
     ~HistorySearch() override;
@@ -55,7 +64,7 @@ private:
 
 
     EmulationPtr m_emulation;
-    QRegExp m_regExp;
+    RegExp m_regExp;
     bool m_forwards;
     int m_startColumn;
     int m_startLine;

--- a/lib/HistorySearch.h
+++ b/lib/HistorySearch.h
@@ -29,7 +29,7 @@
 #include "Emulation.h"
 #include "TerminalCharacterDecoder.h"
 
-#if QT_VERSION >= 0x06000
+#if QT_VERSION >= 0x060000
 #include <QRegularExpression>
 #include <QtCore5Compat/QRegExp>
 #endif
@@ -37,7 +37,7 @@
 using namespace Konsole;
 
 typedef QPointer<Emulation> EmulationPtr;
-#if QT_VERSION >= 0x06000
+#if QT_VERSION >= 0x060000
 typedef QRegularExpression RegExp;
 #else
 typedef QRegExp RegExp;

--- a/lib/KeyboardTranslator.cpp
+++ b/lib/KeyboardTranslator.cpp
@@ -456,8 +456,11 @@ bool KeyboardTranslatorReader::parseAsKeyCode(const QString& item , int& keyCode
     QKeySequence sequence = QKeySequence::fromString(item);
     if ( !sequence.isEmpty() )
     {
+#if QT_VERSION >= 0x060000
+        keyCode = sequence[0].toCombined();
+#else
         keyCode = sequence[0];
-
+#endif
         if ( sequence.count() > 1 )
         {
             qDebug() << "Unhandled key codes in sequence: " << item;

--- a/lib/KeyboardTranslator.cpp
+++ b/lib/KeyboardTranslator.cpp
@@ -34,7 +34,10 @@
 #include <QKeySequence>
 #include <QDir>
 #include <QtDebug>
-
+#if QT_VERSION >= 0x060000
+#include <QtCore5Compat/QRegExp>
+#include <QtCore5Compat/QStringRef>
+#endif
 #include "tools.h"
 
 // KDE
@@ -676,7 +679,8 @@ QByteArray KeyboardTranslator::Entry::escapedText(bool expandWildCards,Qt::Keybo
 
         if ( replacement == 'x' )
         {
-            result.replace(i,1,"\\x"+QByteArray(1,ch).toHex());
+            QByteArray data = "\\x"+QByteArray(1,ch).toHex();
+            result.replace(i,1,data);
         } else if ( replacement != 0 )
         {
             result.remove(i,1);
@@ -694,7 +698,7 @@ QByteArray KeyboardTranslator::Entry::unescape(const QByteArray& input) const
     for ( int i = 0 ; i < result.count()-1 ; i++ )
     {
 
-        QByteRef ch = result[i];
+        auto ch = result[i];
         if ( ch == '\\' )
         {
            char replacement[2] = {0,0};

--- a/lib/Pty.cpp
+++ b/lib/Pty.cpp
@@ -318,10 +318,11 @@ int Pty::foregroundProcessGroup() const
     return 0;
 }
 
+// TODO: we need to handle this
+#if QT_VERSION < 0x060000
 void Pty::setupChildProcess()
 {
     KPtyProcess::setupChildProcess();
-
     // reset all signal handlers
     // this ensures that terminal applications respond to
     // signals generated via key sequences such as Ctrl+C
@@ -338,3 +339,4 @@ void Pty::setupChildProcess()
     }
     sigprocmask(SIG_UNBLOCK, &sigset, nullptr);
 }
+#endif

--- a/lib/Pty.h
+++ b/lib/Pty.h
@@ -187,10 +187,10 @@ Q_OBJECT
      * @param length Length of @p buffer
      */
     void receivedData(const char* buffer, int length);
-
+#if QT_VERSION < 0x060000
   protected:
       void setupChildProcess() override;
-
+#endif
   private slots:
     // called when data is received from the terminal process
     void dataReceived();

--- a/lib/SearchBar.cpp
+++ b/lib/SearchBar.cpp
@@ -18,7 +18,11 @@
 */
 #include <QMenu>
 #include <QAction>
+#if QT_VERSION > 0x060000
+#include <QRegularExpression>
+#else
 #include <QRegExp>
+#endif
 #include <QDebug>
 
 #include "SearchBar.h"

--- a/lib/SearchBar.h
+++ b/lib/SearchBar.h
@@ -19,10 +19,14 @@
 #ifndef _SEARCHBAR_H
 #define	_SEARCHBAR_H
 
-#include <QRegExp>
-
 #include "ui_SearchBar.h"
 #include "HistorySearch.h"
+
+#if QT_VERSION < 0x060000
+#include <QRegExp>
+#else
+#include <QRegularExpression>
+#endif
 
 class SearchBar : public QWidget {
     Q_OBJECT

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -30,10 +30,14 @@
 
 // Qt
 #include <QApplication>
+#if QT_VERSION < 0x060000
+#include <QRegExp>
 #include <QByteRef>
+#else
+#include <QRegularExpression>
+#endif
 #include <QDir>
 #include <QFile>
-#include <QRegExp>
 #include <QStringList>
 #include <QFile>
 #include <QtDebug>
@@ -381,7 +385,7 @@ void Session::setUserTitle( int what, const QString & caption )
 
     if (what == 31) {
         QString cwd=caption;
-        cwd=cwd.replace( QRegExp(QLatin1String("^~")), QDir::homePath() );
+        cwd=cwd.replace( QRegularExpression(QLatin1String("^~")), QDir::homePath() );
         emit openUrlRequest(cwd);
     }
 

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -385,7 +385,11 @@ void Session::setUserTitle( int what, const QString & caption )
 
     if (what == 31) {
         QString cwd=caption;
+#if QT_VERSION >= 0x060000
         cwd=cwd.replace( QRegularExpression(QLatin1String("^~")), QDir::homePath() );
+#else
+        cwd=cwd.replace( QRegExp(QLatin1String("^~")), QDir::homePath() );
+#endif
         emit openUrlRequest(cwd);
     }
 

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2142,8 +2142,13 @@ void TerminalDisplay::mouseMoveEvent(QMouseEvent* ev)
 
 //   int distance = KGlobalSettings::dndEventDelay();
    int distance = QApplication::startDragDistance();
+#if QT_VERSION >= 0x060000
+   if ( ev->position().x() > dragInfo.start.x() + distance || ev->position().x() < dragInfo.start.x() - distance ||
+        ev->position().y() > dragInfo.start.y() + distance || ev->position().y() < dragInfo.start.y() - distance)
+#else
    if ( ev->x() > dragInfo.start.x() + distance || ev->x() < dragInfo.start.x() - distance ||
         ev->y() > dragInfo.start.y() + distance || ev->y() < dragInfo.start.y() - distance)
+#endif
    {
       // we've left the drag square, we can start a real drag operation now
       emit isBusySelecting(false); // Ok.. we can breath again.

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -280,7 +280,9 @@ void TerminalDisplay::setVTFont(const QFont& f)
   //     this ensures the same handling for all platforms
   // but then there was revealed that various Linux distros
   // have this problem too...
+#if QT_VERSION < 0x060000
   font.setStyleStrategy(QFont::ForceIntegerMetrics);
+#endif
 
   if ( !QFontInfo(font).fixedPitch() )
   {
@@ -2016,7 +2018,13 @@ void TerminalDisplay::mousePressEvent(QMouseEvent* ev)
           spot->activate(QLatin1String("click-action"));
     }
   }
-  else if ( ev->button() == Qt::MidButton )
+  else if ( ev->button() ==
+          #if QT_VERSION >= 0x060000
+            Qt::MiddleButton
+          #else
+            Qt::MidButton
+          #endif
+            )
   {
     if ( _mouseMarks || (ev->modifiers() & Qt::ShiftModifier) )
       emitSelection(true,ev->modifiers() & Qt::ControlModifier);
@@ -2107,7 +2115,13 @@ void TerminalDisplay::mouseMoveEvent(QMouseEvent* ev)
     int button = 3;
     if (ev->buttons() & Qt::LeftButton)
         button = 0;
-    if (ev->buttons() & Qt::MidButton)
+    if (ev->buttons() &
+        #if QT_VERSION >= 0x060000
+          Qt::MiddleButton
+        #else
+          Qt::MidButton
+        #endif
+        )
         button = 1;
     if (ev->buttons() & Qt::RightButton)
         button = 2;
@@ -2149,7 +2163,13 @@ void TerminalDisplay::mouseMoveEvent(QMouseEvent* ev)
   if (_actSel == 0) return;
 
  // don't extend selection while pasting
-  if (ev->buttons() & Qt::MidButton) return;
+  if (ev->buttons() &
+        #if QT_VERSION >= 0x060000
+          Qt::MiddleButton
+        #else
+          Qt::MidButton
+        #endif
+          ) return;
 
   extendSelection( ev->pos() );
 }
@@ -2401,12 +2421,23 @@ void TerminalDisplay::mouseReleaseEvent(QMouseEvent* ev)
     dragInfo.state = diNone;
   }
 
-
   if ( !_mouseMarks &&
        ((ev->button() == Qt::RightButton && !(ev->modifiers() & Qt::ShiftModifier))
-                        || ev->button() == Qt::MidButton) )
+                        || ev->button() ==
+      #if QT_VERSION >= 0x060000
+        Qt::MiddleButton
+      #else
+        Qt::MidButton
+      #endif
+        ) )
   {
-    emit mouseSignal( ev->button() == Qt::MidButton ? 1 : 2,
+    emit mouseSignal( ev->button() ==
+                #if QT_VERSION >= 0x060000
+                      Qt::MiddleButton
+                    #else
+                      Qt::MidButton
+                #endif
+                      ? 1 : 2,
                       charColumn + 1,
                       charLine + 1 +_scrollBar->value() -_scrollBar->maximum() ,
                       2);
@@ -2516,6 +2547,7 @@ void TerminalDisplay::mouseDoubleClickEvent(QMouseEvent* ev)
      // find the end of the word
      i = loc( endSel.x(), endSel.y() );
      x = endSel.x();
+
      while( ((x<_usedColumns-1) || (endSel.y()<_usedLines-1 && (_lineProperties[endSel.y()] & LINE_WRAPPED) ))
                      && charClass(_image[i+1].character) == selClass )
      {
@@ -2895,7 +2927,7 @@ QVariant TerminalDisplay::inputMethodQuery( Qt::InputMethodQuery query ) const
     const QPoint cursorPos = _screenWindow ? _screenWindow->cursorPosition() : QPoint(0,0);
     switch ( query )
     {
-        case Qt::ImMicroFocus:
+        case Qt::ImCursorRectangle:
                 return imageToWidget(QRect(cursorPos.x(),cursorPos.y(),1,1));
             break;
         case Qt::ImFont:

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -172,6 +172,13 @@ void TerminalDisplay::setForegroundColor(const QColor& color)
 
     update();
 }
+
+void TerminalDisplay::setColorTableColor(const int colorId, const QColor &color)
+{
+    _colorTable[colorId].color = color;
+    update();
+}
+
 void TerminalDisplay::setColorTable(const ColorEntry table[])
 {
   for (int i = 0; i < TABLE_COLORS; i++)

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -525,7 +525,7 @@ public slots:
      * @see setColorTable(), setBackgroundColor()
      */
     void setForegroundColor(const QColor& color);
-
+    void setColorTableColor(const int colorId, const QColor &color);
     void selectionChanged();
 
 signals:

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -45,7 +45,12 @@
 // Qt
 #include <QEvent>
 #include <QKeyEvent>
+#if QT_VERSION >= 0x060000
+#include <QByteArrayView>
+#include <QtCore5Compat/QTextCodec>
+#else
 #include <QByteRef>
+#endif
 #include <QDebug>
 
 // KDE
@@ -971,8 +976,8 @@ void Vt102Emulation::sendMouseEvent( int cb, int cx, int cy , int eventType )
             // coordinate+32, no matter what the locale is. We could easily
             // convert manually, but QString can also do it for us.
             QChar coords[2];
-            coords[0] = cx + 0x20;
-            coords[1] = cy + 0x20;
+            coords[0] = QChar(cx + 0x20);
+            coords[1] = QChar(cy + 0x20);
             QString coordsStr = QString(coords, 2);
             QByteArray utf8 = coordsStr.toUtf8();
             snprintf(command, sizeof(command), "\033[M%c%s", cb + 0x20, utf8.constData());

--- a/lib/kprocess.h
+++ b/lib/kprocess.h
@@ -324,8 +324,10 @@ protected:
 
 private:
     // hide those
+#if QT_VERSION < 0x060000
     using QProcess::setReadChannelMode;
     using QProcess::readChannelMode;
+#endif
     using QProcess::setProcessChannelMode;
     using QProcess::processChannelMode;
 

--- a/lib/kptyprocess.cpp
+++ b/lib/kptyprocess.cpp
@@ -119,6 +119,7 @@ KPtyDevice *KPtyProcess::pty() const
     return d->pty;
 }
 
+#if QT_VERSION < 0x060000
 void KPtyProcess::setupChildProcess()
 {
     Q_D(KPtyProcess);
@@ -140,5 +141,6 @@ void KPtyProcess::setupChildProcess()
 
     KProcess::setupChildProcess();
 }
+#endif
 
 //#include "kptyprocess.moc"

--- a/lib/kptyprocess.cpp
+++ b/lib/kptyprocess.cpp
@@ -46,6 +46,26 @@ KPtyProcess::KPtyProcess(QObject *parent) :
     d->pty->open();
     connect(this, SIGNAL(stateChanged(QProcess::ProcessState)),
             SLOT(_k_onStateChanged(QProcess::ProcessState)));
+
+#if QT_VERSION >= 0x060000
+    setChildProcessModifier([this] {
+        Q_D(KPtyProcess);
+        d->pty->setCTty();
+
+    #if 0
+        if (d->addUtmp)
+            d->pty->login(KUser(KUser::UseRealUserID).loginName().toLocal8Bit().data(), qgetenv("DISPLAY"));
+    #endif
+        if (d->ptyChannels & StdinChannel)
+            dup2(d->pty->slaveFd(), 0);
+
+        if (d->ptyChannels & StdoutChannel)
+            dup2(d->pty->slaveFd(), 1);
+
+        if (d->ptyChannels & StderrChannel)
+            dup2(d->pty->slaveFd(), 2);
+    });
+#endif
 }
 
 KPtyProcess::KPtyProcess(int ptyMasterFd, QObject *parent) :

--- a/lib/kptyprocess.h
+++ b/lib/kptyprocess.h
@@ -144,8 +144,9 @@ protected:
     /**
      * @reimp
      */
+#if QT_VERSION < 0x060000
     void setupChildProcess() override;
-
+#endif
 private:
     Q_PRIVATE_SLOT(d_func(), void _k_onStateChanged(QProcess::ProcessState))
 };

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -21,6 +21,9 @@
 #include <QtDebug>
 #include <QDir>
 #include <QMessageBox>
+#if QT_VERSION >= 0x060000
+#include <QRegularExpression>
+#endif
 
 #include "ColorTables.h"
 #include "Session.h"
@@ -167,10 +170,16 @@ void QTermWidget::search(bool forwards, bool next)
     //qDebug() << "current selection starts at: " << startColumn << startLine;
     //qDebug() << "current cursor position: " << m_impl->m_terminalDisplay->screenWindow()->cursorPosition();
 
+#if QT_VERSION < 0x060000
     QRegExp regExp(m_searchBar->searchText());
     regExp.setPatternSyntax(m_searchBar->useRegularExpression() ? QRegExp::RegExp : QRegExp::FixedString);
     regExp.setCaseSensitivity(m_searchBar->matchCase() ? Qt::CaseSensitive : Qt::CaseInsensitive);
-
+#else
+    QRegularExpression regExp(m_searchBar->searchText(),
+                              m_searchBar->matchCase() ? QRegularExpression::CaseInsensitiveOption|
+                                                         QRegularExpression::UseUnicodePropertiesOption
+                                                       : QRegularExpression::UseUnicodePropertiesOption);
+#endif
     HistorySearch *historySearch =
             new HistorySearch(m_impl->m_session->emulation(), regExp, forwards, startColumn, startLine, this);
     connect(historySearch, SIGNAL(matchFound(int, int, int, int)), this, SLOT(matchFound(int, int, int, int)));
@@ -261,7 +270,9 @@ void QTermWidget::startTerminalTeletype()
 void QTermWidget::init(int startnow)
 {
     m_layout = new QVBoxLayout();
+#if QT_VERSION < 0x060000
     m_layout->setMargin(0);
+#endif
     setLayout(m_layout);
 
     // translations

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -497,6 +497,21 @@ void QTermWidget::addCustomColorSchemeDir(const QString& custom_dir)
     ColorSchemeManager::instance()->addCustomColorSchemeDir(custom_dir);
 }
 
+void QTermWidget::setBackgroundColor(const QColor &color)
+{
+    m_impl->m_terminalDisplay->setBackgroundColor(color);
+}
+
+void QTermWidget::setForegroundColor(const QColor &color)
+{
+    m_impl->m_terminalDisplay->setForegroundColor(color);
+}
+
+void QTermWidget::setANSIColor(const int ansiColorId, const QColor &color)
+{
+    m_impl->m_terminalDisplay->setColorTableColor(ansiColorId+2, color);
+}
+
 void QTermWidget::setSize(const QSize &size)
 {
     m_impl->m_terminalDisplay->setSize(size.width(), size.height());

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -509,7 +509,7 @@ void QTermWidget::setForegroundColor(const QColor &color)
 
 void QTermWidget::setANSIColor(const int ansiColorId, const QColor &color)
 {
-    m_impl->m_terminalDisplay->setColorTableColor(ansiColorId+2, color);
+    m_impl->m_terminalDisplay->setColorTableColor(ansiColorId, color);
 }
 
 void QTermWidget::setSize(const QSize &size)

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -272,6 +272,8 @@ void QTermWidget::init(int startnow)
     m_layout = new QVBoxLayout();
 #if QT_VERSION < 0x060000
     m_layout->setMargin(0);
+#else
+    m_layout->setContentsMargins(0,0,0,0);
 #endif
     setLayout(m_layout);
 

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -115,6 +115,11 @@ public:
     static QStringList availableColorSchemes();
     static void addCustomColorSchemeDir(const QString& custom_dir);
 
+    void setBackgroundColor(const QColor &color);
+    void setForegroundColor(const QColor &color);
+    void setANSIColor(const int ansiColorId, const QColor &color);
+
+
     /** Sets the history size (in lines)
      *
      * @param lines history size


### PR DESCRIPTION
i have created these patches to update qtermwidget to compile and function on qt 6.
it requires the qt5compat module for qtextencoding support.  kde & others seem to be currently at no concrete decision on how to handle the loss of qtextcodec & friends in qt6 as my (admitted limited) research has shown.  this is sad as the replacement in qt6 is insanely limited in comparison..

this adds cmake variable -DUSE_QT6 which defaults to off.  

i've been eating my own dog food by using a qt5 build in qterminal and a qt6 build in my own stuff and so far so good.  i haven't seen any regressions in qterminal using my library in-place instead.

thanks,
~cat