### PR TITLE
Fix possible crash when accesing destroyed objects

### DIFF
--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -72,7 +72,7 @@ Emulation::Emulation() :
   connect(this , SIGNAL(programBracketedPasteModeChanged(bool)) ,
            SLOT(bracketedPasteModeChanged(bool)));
 
-  connect(this, &Emulation::cursorChanged, [this] (KeyboardCursorShape cursorShape, bool blinkingCursorEnabled) {
+  connect(this, &Emulation::cursorChanged, this, [this] (KeyboardCursorShape cursorShape, bool blinkingCursorEnabled) {
     emit titleChanged( 50, QString(QLatin1String("CursorShape=%1;BlinkingCursorEnabled=%2"))
                                .arg(static_cast<int>(cursorShape)).arg(blinkingCursorEnabled) );
   });

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -324,7 +324,7 @@ void QTermWidget::init(int startnow)
             this, SIGNAL(termGetFocus()));
     connect(m_impl->m_terminalDisplay, SIGNAL(termLostFocus()),
             this, SIGNAL(termLostFocus()));
-    connect(m_impl->m_terminalDisplay, &TerminalDisplay::keyPressedSignal,
+    connect(m_impl->m_terminalDisplay, &TerminalDisplay::keyPressedSignal, this,
             [this] (QKeyEvent* e, bool) { Q_EMIT termKeyPressed(e); });
 //    m_impl->m_terminalDisplay->setSize(80, 40);
 


### PR DESCRIPTION
When using lambdas in connects that capture `this`, it's necessary to pass this as object. Otherwise, the lambda will be a static function that could access a destroyed object.