### PR TITLE
Modernize code (Qt5 connects + init of params)

### DIFF
--- a/lib/Emulation.h
+++ b/lib/Emulation.h
@@ -474,7 +474,7 @@ protected:
 
   QList<ScreenWindow*> _windows;
 
-  Screen* _currentScreen;  // pointer to the screen which is currently active,
+  Screen* _currentScreen = nullptr;  // pointer to the screen which is currently active,
                             // this is one of the elements in the screen[] array
 
   Screen* _screen[2];      // 0 = primary screen ( used by most programs, including the shell
@@ -485,9 +485,9 @@ protected:
 
   //decodes an incoming C-style character stream into a unicode QString using
   //the current text codec.  (this allows for rendering of non-ASCII characters in text files etc.)
-  const QTextCodec* _codec;
-  QTextDecoder* _decoder;
-  const KeyboardTranslator* _keyTranslator; // the keyboard layout
+  const QTextCodec* _codec = nullptr;
+  QTextDecoder* _decoder = nullptr;
+  const KeyboardTranslator* _keyTranslator = nullptr; // the keyboard layout
 
 protected slots:
   /**
@@ -508,8 +508,8 @@ private slots:
   void bracketedPasteModeChanged(bool bracketedPasteMode);
 
 private:
-  bool _usesMouse;
-  bool _bracketedPasteMode;
+  bool _usesMouse = false;
+  bool _bracketedPasteMode = false;
   QTimer _bulkTimer1;
   QTimer _bulkTimer2;
 

--- a/lib/Filter.cpp
+++ b/lib/Filter.cpp
@@ -283,7 +283,6 @@ Filter::HotSpot::HotSpot(int startLine , int startColumn , int endLine , int end
     , _startColumn(startColumn)
     , _endLine(endLine)
     , _endColumn(endColumn)
-    , _type(NotSpecified)
 {
 }
 QList<QAction*> Filter::HotSpot::actions()
@@ -421,8 +420,9 @@ UrlFilter::HotSpot::UrlType UrlFilter::HotSpot::urlType() const
         return StandardUrl;
     else if ( EmailAddressRegExp.exactMatch(url) )
         return Email;
-    else
-        return Unknown;
+
+
+    return Unknown;
 }
 
 void UrlFilter::HotSpot::activate(const QString& actionName)

--- a/lib/Filter.h
+++ b/lib/Filter.h
@@ -127,7 +127,7 @@ public:
        int    _startColumn;
        int    _endLine;
        int    _endColumn;
-       Type _type;
+       Type _type = NotSpecified;
 
     };
 

--- a/lib/History.cpp
+++ b/lib/History.cpp
@@ -88,10 +88,6 @@ FIXME: There is noticeable decrease in speed, also. Perhaps,
 */
 
 HistoryFile::HistoryFile()
-  : ion(-1),
-    length(0),
-    fileMap(nullptr),
-    readWriteBalance(0)
 {
   if (tmpFile.open())
   {
@@ -177,7 +173,7 @@ void HistoryFile::get(unsigned char* bytes, int len, int loc)
   }
 }
 
-int HistoryFile::len()
+int HistoryFile::len() const
 {
   return length;
 }
@@ -217,10 +213,6 @@ bool HistoryScroll::hasScroll()
 HistoryScrollFile::HistoryScrollFile(const QString &logFileName)
   : HistoryScroll(new HistoryTypeFile(logFileName)),
   m_logFileName(logFileName)
-{
-}
-
-HistoryScrollFile::~HistoryScrollFile()
 {
 }
 
@@ -422,10 +414,6 @@ int HistoryScrollBuffer::bufferIndex(int lineNumber) const
 
 HistoryScrollNone::HistoryScrollNone()
   : HistoryScroll(new HistoryTypeNone())
-{
-}
-
-HistoryScrollNone::~HistoryScrollNone()
 {
 }
 

--- a/lib/History.h
+++ b/lib/History.h
@@ -53,7 +53,7 @@ public:
 
   virtual void add(const unsigned char* bytes, int len);
   virtual void get(unsigned char* bytes, int len, int loc);
-  virtual int  len();
+  virtual int len() const final;
 
   //mmaps the file in read-only mode
   void map();
@@ -64,18 +64,18 @@ public:
 
 
 private:
-  int  ion;
-  int  length;
+  int  ion = -1;
+  int  length = 0;
   QTemporaryFile tmpFile;
 
   //pointer to start of mmap'ed file data, or 0 if the file is not mmap'ed
-  char* fileMap;
+  char* fileMap = nullptr;
 
   //incremented whenver 'add' is called and decremented whenever
   //'get' is called.
   //this is used to detect when a large number of lines are being read and processed from the history
   //and automatically mmap the file for better performance (saves the overhead of many lseek-read calls).
-  int readWriteBalance;
+  int readWriteBalance = 0;
 
   //when readWriteBalance goes below this threshold, the file will be mmap'ed automatically
   static const int MAP_THRESHOLD = -1000;
@@ -125,7 +125,7 @@ public:
   const HistoryType& getType() { return *m_histType; }
 
 protected:
-  HistoryType* m_histType;
+  HistoryType* m_histType = nullptr;
 
 };
 
@@ -135,11 +135,11 @@ protected:
 // File-based history (e.g. file log, no limitation in length)
 //////////////////////////////////////////////////////////////////////
 
-class HistoryScrollFile : public HistoryScroll
+class HistoryScrollFile final : public HistoryScroll
 {
 public:
   HistoryScrollFile(const QString &logFileName);
-  ~HistoryScrollFile() override;
+  ~HistoryScrollFile() override = default;
 
   int  getLines() override;
   int  getLineLen(int lineno) override;
@@ -162,7 +162,7 @@ private:
 //////////////////////////////////////////////////////////////////////
 // Buffer-based history (limited to a fixed nb of lines)
 //////////////////////////////////////////////////////////////////////
-class HistoryScrollBuffer : public HistoryScroll
+class HistoryScrollBuffer final : public HistoryScroll
 {
 public:
   typedef QVector<Character> HistoryLine;
@@ -219,11 +219,11 @@ public:
 //////////////////////////////////////////////////////////////////////
 // Nothing-based history (no history :-)
 //////////////////////////////////////////////////////////////////////
-class HistoryScrollNone : public HistoryScroll
+class HistoryScrollNone final : public HistoryScroll
 {
 public:
   HistoryScrollNone();
-  ~HistoryScrollNone() override;
+  ~HistoryScrollNone() override = default;
 
   bool hasScroll() override;
 

--- a/lib/Pty.cpp
+++ b/lib/Pty.cpp
@@ -256,6 +256,7 @@ Pty::Pty(int masterFd, QObject* parent)
 {
     init();
 }
+
 Pty::Pty(QObject* parent)
     : KPtyProcess(parent)
 {
@@ -263,13 +264,7 @@ Pty::Pty(QObject* parent)
 }
 void Pty::init()
 {
-  _windowColumns = 0;
-  _windowLines = 0;
-  _eraseChar = 0;
-  _xonXoff = true;
-  _utf8 =true;
-
-  connect(pty(), SIGNAL(readyRead()) , this , SLOT(dataReceived()));
+  connect(pty(), &KPtyDevice::readyRead, this , &Pty::dataReceived);
   setPtyChannels(KPtyProcess::AllChannels);
 }
 

--- a/lib/Pty.h
+++ b/lib/Pty.h
@@ -191,10 +191,6 @@ Q_OBJECT
   protected:
       void setupChildProcess() override;
 
-  private slots:
-    // called when data is received from the terminal process
-    void dataReceived();
-
   private:
       void init();
 
@@ -202,11 +198,14 @@ Q_OBJECT
     // to the environment for the process
     void addEnvironmentVariables(const QStringList& environment);
 
-    int  _windowColumns;
-    int  _windowLines;
-    char _eraseChar;
-    bool _xonXoff;
-    bool _utf8;
+    // called when data is received from the terminal process
+    void dataReceived();
+
+    int  _windowColumns = 0;
+    int  _windowLines = 0;
+    char _eraseChar = 0;
+    bool _xonXoff = true;
+    bool _utf8 = true;
 };
 
 }

--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -72,19 +72,10 @@ Character Screen::defaultChar = Character(' ',
 : lines(l),
     columns(c),
     screenLines(new ImageLine[lines+1] ),
-    _scrolledLines(0),
-    _droppedLines(0),
-    history(new HistoryScrollNone()),
-    cuX(0), cuY(0),
-    currentRendition(0),
-    _topMargin(0), _bottomMargin(0),
-    selBegin(0), selTopLeft(0), selBottomRight(0),
-    blockSelectionMode(false),
-    effectiveForeground(CharacterColor()), effectiveBackground(CharacterColor()), effectiveRendition(0),
-    lastPos(-1)
+    history(new HistoryScrollNone())
 {
     lineProperties.resize(lines+1);
-    for (int i=0;i<lines+1;i++)
+    for (int i=0; i < lines+1; ++i)
         lineProperties[i]=LINE_DEFAULT;
 
     initTabStops();

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -625,28 +625,28 @@ private:
     typedef QVector<Character> ImageLine;      // [0..columns]
     ImageLine*          screenLines;    // [lines]
 
-    int _scrolledLines;
+    int _scrolledLines = 0;
     QRect _lastScrolledRegion;
 
-    int _droppedLines;
+    int _droppedLines = 0;
 
     QVarLengthArray<LineProperty,64> lineProperties;
 
     // history buffer ---------------
-    HistoryScroll* history;
+    HistoryScroll* history = nullptr;
 
     // cursor location
-    int cuX;
-    int cuY;
+    int cuX = 0;
+    int cuY = 0;
 
     // cursor color and rendition info
     CharacterColor currentForeground;
     CharacterColor currentBackground;
-    quint8 currentRendition;
+    quint8 currentRendition = 0;
 
     // margins ----------------
-    int _topMargin;
-    int _bottomMargin;
+    int _topMargin = 0;
+    int _bottomMargin = 0;
 
     // states ----------------
     bool currentModes[MODES_SCREEN];
@@ -657,15 +657,15 @@ private:
     QBitArray tabStops;
 
     // selection -------------------
-    int selBegin; // The first location selected.
-    int selTopLeft;    // TopLeft Location.
-    int selBottomRight;    // Bottom Right Location.
-    bool blockSelectionMode;  // Column selection mode
+    int selBegin = 0; // The first location selected.
+    int selTopLeft = 0;    // TopLeft Location.
+    int selBottomRight = 0;    // Bottom Right Location.
+    bool blockSelectionMode = false;  // Column selection mode
 
     // effective colors and rendition ------------
     CharacterColor effectiveForeground; // These are derived from
     CharacterColor effectiveBackground; // the cu_* variables above
-    quint8 effectiveRendition;          // to speed up operation
+    quint8 effectiveRendition = 0;          // to speed up operation
 
     class SavedState
     {
@@ -682,7 +682,7 @@ private:
     SavedState savedState;
 
     // last position where we added a character
-    int lastPos;
+    int lastPos = -1;
 
     // used in REP (repeating char)
     unsigned short lastDrawnChar;

--- a/lib/ScreenWindow.cpp
+++ b/lib/ScreenWindow.cpp
@@ -30,20 +30,14 @@ using namespace Konsole;
 
 ScreenWindow::ScreenWindow(QObject* parent)
     : QObject(parent)
-    , _screen(nullptr)
-    , _windowBuffer(nullptr)
-    , _windowBufferSize(0)
-    , _bufferNeedsUpdate(true)
-    , _windowLines(1)
-    , _currentLine(0)
-    , _trackOutput(true)
-    , _scrollCount(0)
 {
 }
+
 ScreenWindow::~ScreenWindow()
 {
     delete[] _windowBuffer;
 }
+
 void ScreenWindow::setScreen(Screen* screen)
 {
     Q_ASSERT( screen );

--- a/lib/ScreenWindow.h
+++ b/lib/ScreenWindow.h
@@ -248,15 +248,15 @@ private:
     int endWindowLine() const;
     void fillUnusedArea();
 
-    Screen* _screen; // see setScreen() , screen()
-    Character* _windowBuffer;
-    int _windowBufferSize;
-    bool _bufferNeedsUpdate;
+    Screen* _screen = nullptr; // see setScreen() , screen()
+    Character* _windowBuffer = nullptr;
+    int _windowBufferSize = 0;
+    bool _bufferNeedsUpdate = true;
 
-    int  _windowLines;
-    int  _currentLine; // see scrollTo() , currentLine()
-    bool _trackOutput; // see setTrackOutput() , trackOutput()
-    int  _scrollCount; // count of lines which the window has been scrolled by since
+    int  _windowLines = 1;
+    int  _currentLine = 0; // see scrollTo() , currentLine()
+    bool _trackOutput = true; // see setTrackOutput() , trackOutput()
+    int  _scrollCount = 0; // count of lines which the window has been scrolled by since
                        // the last call to resetScrollCount()
 };
 

--- a/lib/SearchBar.cpp
+++ b/lib/SearchBar.cpp
@@ -28,11 +28,11 @@ SearchBar::SearchBar(QWidget *parent) : QWidget(parent)
     widget.setupUi(this);
     setAutoFillBackground(true); // make it always opaque, especially inside translucent windows
     connect(widget.closeButton, &QAbstractButton::clicked, this, &SearchBar::hide);
-    connect(widget.searchTextEdit, SIGNAL(textChanged(QString)), this, SIGNAL(searchCriteriaChanged()));
-    connect(widget.findPreviousButton, SIGNAL(clicked()), this, SIGNAL(findPrevious()));
-    connect(widget.findNextButton, SIGNAL(clicked()), this, SIGNAL(findNext()));
+    connect(widget.searchTextEdit, &QLineEdit::textChanged, this, &SearchBar::searchCriteriaChanged);
+    connect(widget.findPreviousButton, &QToolButton::clicked, this, &SearchBar::findPrevious);
+    connect(widget.findNextButton, &QToolButton::clicked, this, &SearchBar::findNext);
 
-    connect(this, SIGNAL(searchCriteriaChanged()), this, SLOT(clearBackgroundColor()));
+    connect(this, &SearchBar::searchCriteriaChanged, this, &SearchBar::clearBackgroundColor);
 
     QMenu *optionsMenu = new QMenu(widget.optionsButton);
     widget.optionsButton->setMenu(optionsMenu);
@@ -45,34 +45,34 @@ SearchBar::SearchBar(QWidget *parent) : QWidget(parent)
 
     m_useRegularExpressionMenuEntry = optionsMenu->addAction(tr("Regular expression"));
     m_useRegularExpressionMenuEntry->setCheckable(true);
-    connect(m_useRegularExpressionMenuEntry, SIGNAL(toggled(bool)), this, SIGNAL(searchCriteriaChanged()));
+    connect(m_useRegularExpressionMenuEntry, &QAction::toggled, this, &SearchBar::searchCriteriaChanged);
 
     m_highlightMatchesMenuEntry = optionsMenu->addAction(tr("Highlight all matches"));
     m_highlightMatchesMenuEntry->setCheckable(true);
     m_highlightMatchesMenuEntry->setChecked(true);
-    connect(m_highlightMatchesMenuEntry, SIGNAL(toggled(bool)), this, SIGNAL(highlightMatchesChanged(bool)));
+    connect(m_highlightMatchesMenuEntry, &QAction::toggled, this, &SearchBar::highlightMatchesChanged);
 }
 
 SearchBar::~SearchBar() {
 }
 
-QString SearchBar::searchText()
+QString SearchBar::searchText() const
 {
     return widget.searchTextEdit->text();
 }
 
 
-bool SearchBar::useRegularExpression()
+bool SearchBar::useRegularExpression() const
 {
     return m_useRegularExpressionMenuEntry->isChecked();
 }
 
-bool SearchBar::matchCase()
+bool SearchBar::matchCase() const
 {
     return m_matchCaseMenuEntry->isChecked();
 }
 
-bool SearchBar::highlightAllMatches()
+bool SearchBar::highlightAllMatches() const
 {
     return m_highlightMatchesMenuEntry->isChecked();
 }
@@ -107,11 +107,11 @@ void SearchBar::keyReleaseEvent(QKeyEvent* keyEvent)
     {
         if (keyEvent->modifiers() == Qt::ShiftModifier)
         {
-            Q_EMIT findPrevious();
+            emit findPrevious();
         }
         else
         {
-            Q_EMIT findNext();
+            emit findNext();
         }
     }
     else if (keyEvent->key() == Qt::Key_Escape)

--- a/lib/SearchBar.cpp
+++ b/lib/SearchBar.cpp
@@ -40,7 +40,7 @@ SearchBar::SearchBar(QWidget *parent) : QWidget(parent)
     m_matchCaseMenuEntry = optionsMenu->addAction(tr("Match case"));
     m_matchCaseMenuEntry->setCheckable(true);
     m_matchCaseMenuEntry->setChecked(true);
-    connect(m_matchCaseMenuEntry, SIGNAL(toggled(bool)), this, SIGNAL(searchCriteriaChanged()));
+    connect(m_matchCaseMenuEntry, &QAction::toggled, this, &SearchBar::searchCriteriaChanged);
 
 
     m_useRegularExpressionMenuEntry = optionsMenu->addAction(tr("Regular expression"));

--- a/lib/SearchBar.h
+++ b/lib/SearchBar.h
@@ -30,12 +30,10 @@ public:
     SearchBar(QWidget* parent = nullptr);
     ~SearchBar() override;
     virtual void show();
-    QString searchText();
-    bool useRegularExpression();
-    bool matchCase();
-    bool highlightAllMatches();
-
-public slots:
+    QString searchText() const;
+    bool useRegularExpression() const;
+    bool matchCase() const;
+    bool highlightAllMatches() const;
     void noMatchFound();
     void hide();
 
@@ -48,14 +46,13 @@ signals:
 protected:
     void keyReleaseEvent(QKeyEvent* keyEvent) override;
 
-private slots:
+private:
     void clearBackgroundColor();
 
-private:
     Ui::SearchBar widget;
-    QAction *m_matchCaseMenuEntry;
-    QAction *m_useRegularExpressionMenuEntry;
-    QAction *m_highlightMatchesMenuEntry;
+    QAction *m_matchCaseMenuEntry = nullptr;
+    QAction *m_useRegularExpressionMenuEntry = nullptr;
+    QAction *m_highlightMatchesMenuEntry = nullptr;
 };
 
 #endif	/* _SEARCHBAR_H */

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -88,7 +88,7 @@ Session::Session(QObject* parent) :
 
     //setup timer for monitoring session activity
     _monitorTimer->setSingleShot(true);
-    connect(_monitorTimer, SIGNAL(timeout()), this, SLOT(monitorTimerDone()));
+    connect(_monitorTimer, &QTimer::timeout, this, &Session::monitorTimerDone);
 }
 
 WId Session::windowId() const
@@ -147,7 +147,7 @@ void Session::addView(TerminalDisplay * widget)
         connect(widget, &TerminalDisplay::keyPressedSignal, _emulation, &Emulation::sendKeyEvent);
         connect(widget, &TerminalDisplay::mouseSignal, _emulation, &Emulation::sendMouseEvent);
         connect( widget , SIGNAL(sendStringToEmu(const char *)) , _emulation ,
-                 SLOT(sendString(const char *)) );
+                SLOT(sendString(const char *)) );
 
         // allow emulation to notify view when the foreground process
         // indicates whether or not it is interested in mouse signals
@@ -155,8 +155,7 @@ void Session::addView(TerminalDisplay * widget)
 
         widget->setUsesMouse( _emulation->programUsesMouse() );
 
-        connect( _emulation , SIGNAL(programBracketedPasteModeChanged(bool)) ,
-                 widget , SLOT(setBracketedPasteMode(bool)) );
+        connect(_emulation , &Emulation::programBracketedPasteModeChanged, widget , &TerminalDisplay::setBracketedPasteMode);
 
         widget->setBracketedPasteMode(_emulation->programBracketedPasteMode());
 

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -49,28 +49,10 @@ using namespace Konsole;
 int Session::lastSessionId = 0;
 
 Session::Session(QObject* parent) :
-    QObject(parent),
-        _shellProcess(nullptr)
-        , _emulation(nullptr)
-        , _monitorActivity(false)
-        , _monitorSilence(false)
-        , _notifiedActivity(false)
-        , _autoClose(true)
-        , _wantedClose(false)
-        , _silenceSeconds(10)
-        , _isTitleChanged(false)
-        , _addToUtmp(false)  // disabled by default because of a bug encountered on certain systems
-        // which caused Konsole to hang when closing a tab and then opening a new
-        // one.  A 'QProcess destroyed while still running' warning was being
-        // printed to the terminal.  Likely a problem in KPty::logout()
-        // or KPty::login() which uses a QProcess to start /usr/bin/utempter
-        , _flowControl(true)
-        , _fullScripting(false)
-        , _sessionId(0)
-//   , _zmodemBusy(false)
-//   , _zmodemProc(0)
-//   , _zmodemProgress(0)
-        , _hasDarkBackground(false)
+    QObject(parent)
+    , _shellProcess (new Pty())
+    , _emulation (new Vt102Emulation())
+    , _monitorTimer (new QTimer(this))
 {
     //prepare DBus communication
 //    new SessionAdaptor(this);
@@ -78,45 +60,33 @@ Session::Session(QObject* parent) :
 //    QDBusConnection::sessionBus().registerObject(QLatin1String("/Sessions/")+QString::number(_sessionId), this);
 
     //create teletype for I/O with shell process
-    _shellProcess = new Pty();
     ptySlaveFd = _shellProcess->pty()->slaveFd();
 
-    //create emulation backend
-    _emulation = new Vt102Emulation();
-
-    connect( _emulation, SIGNAL( titleChanged( int, const QString & ) ),
-             this, SLOT( setUserTitle( int, const QString & ) ) );
-    connect( _emulation, SIGNAL( stateSet(int) ),
-             this, SLOT( activityStateSet(int) ) );
+    connect( _emulation, &Emulation::titleChanged, this, &Session::setUserTitle);
+    connect( _emulation, &Emulation::stateSet, this, &Session::activityStateSet);
 //    connect( _emulation, SIGNAL( zmodemDetected() ), this ,
 //            SLOT( fireZModemDetected() ) );
-    connect( _emulation, SIGNAL( changeTabTextColorRequest( int ) ),
-             this, SIGNAL( changeTabTextColorRequest( int ) ) );
-    connect( _emulation, SIGNAL(profileChangeCommandReceived(const QString &)),
-             this, SIGNAL( profileChangeCommandReceived(const QString &)) );
+    connect( _emulation, &Emulation::changeTabTextColorRequest, this, &Session::changeTabTextColorRequest);
+    connect( _emulation, &Emulation::profileChangeCommandReceived, this, &Session::profileChangeCommandReceived);
 
-    connect(_emulation, SIGNAL(imageResizeRequest(QSize)),
-            this, SLOT(onEmulationSizeChange(QSize)));
-    connect(_emulation, SIGNAL(imageSizeChanged(int, int)),
-            this, SLOT(onViewSizeChange(int, int)));
-    connect(_emulation, &Vt102Emulation::cursorChanged,
+    connect(_emulation, &Emulation::imageResizeRequest, this, &Session::onEmulationSizeChange);
+    connect(_emulation, &Emulation::imageSizeChanged, this, &Session::onViewSizeChange);
+    connect(_emulation, &Emulation::cursorChanged,
             this, &Session::cursorChanged);
 
     //connect teletype to emulation backend
     _shellProcess->setUtf8Mode(_emulation->utf8());
 
-    connect( _shellProcess,SIGNAL(receivedData(const char *,int)),this,
-             SLOT(onReceiveBlock(const char *,int)) );
-    connect( _emulation,SIGNAL(sendData(const char *,int)),_shellProcess,
-             SLOT(sendData(const char *,int)) );
-    connect( _emulation,SIGNAL(lockPtyRequest(bool)),_shellProcess,SLOT(lockPty(bool)) );
-    connect( _emulation,SIGNAL(useUtf8Request(bool)),_shellProcess,SLOT(setUtf8Mode(bool)) );
+    connect( _shellProcess, &Pty::receivedData, this, &Session::onReceiveBlock);
+    connect( _emulation, &Emulation::sendData, _shellProcess, &Pty::sendData);
+    connect( _emulation,&Emulation::lockPtyRequest, _shellProcess, &Pty::lockPty);
+    connect( _emulation,&Emulation::useUtf8Request, _shellProcess, &Pty::setUtf8Mode);
 
+    // Not moved to the new connect way for now to avoid to use qoverload
     connect( _shellProcess,SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(done(int)) );
     // not in kprocess anymore connect( _shellProcess,SIGNAL(done(int)), this, SLOT(done(int)) );
 
     //setup timer for monitoring session activity
-    _monitorTimer = new QTimer(this);
     _monitorTimer->setSingleShot(true);
     connect(_monitorTimer, SIGNAL(timeout()), this, SLOT(monitorTimerDone()));
 }
@@ -174,17 +144,14 @@ void Session::addView(TerminalDisplay * widget)
 
     if ( _emulation != nullptr ) {
         // connect emulation - view signals and slots
-        connect( widget , &TerminalDisplay::keyPressedSignal, _emulation ,
-                 &Emulation::sendKeyEvent);
-        connect( widget , SIGNAL(mouseSignal(int,int,int,int)) , _emulation ,
-                 SLOT(sendMouseEvent(int,int,int,int)) );
+        connect(widget, &TerminalDisplay::keyPressedSignal, _emulation, &Emulation::sendKeyEvent);
+        connect(widget, &TerminalDisplay::mouseSignal, _emulation, &Emulation::sendMouseEvent);
         connect( widget , SIGNAL(sendStringToEmu(const char *)) , _emulation ,
                  SLOT(sendString(const char *)) );
 
         // allow emulation to notify view when the foreground process
         // indicates whether or not it is interested in mouse signals
-        connect( _emulation , SIGNAL(programUsesMouseChanged(bool)) , widget ,
-                 SLOT(setUsesMouse(bool)) );
+        connect(_emulation, &Emulation::programUsesMouseChanged, widget, &TerminalDisplay::setUsesMouse);
 
         widget->setUsesMouse( _emulation->programUsesMouse() );
 
@@ -197,13 +164,9 @@ void Session::addView(TerminalDisplay * widget)
     }
 
     //connect view signals and slots
-    QObject::connect( widget ,SIGNAL(changedContentSizeSignal(int,int)),this,
-                      SLOT(onViewSizeChange(int,int)));
-
-    QObject::connect( widget ,SIGNAL(destroyed(QObject *)) , this ,
-                      SLOT(viewDestroyed(QObject *)) );
-//slot for close
-    QObject::connect(this, SIGNAL(finished()), widget, SLOT(close()));
+    connect(widget, &TerminalDisplay::changedContentSizeSignal, this, &Session::onViewSizeChange);
+    connect(widget, &TerminalDisplay::destroyed, this , &Session::viewDestroyed);
+    connect(this, &Session::finished, widget, &TerminalDisplay::close);
 
 }
 
@@ -539,15 +502,15 @@ void Session::refresh()
 
 bool Session::sendSignal(int signal)
 {
-    int result = ::kill(static_cast<pid_t>(_shellProcess->processId()),signal);
+    const auto result = ::kill(static_cast<pid_t>(_shellProcess->processId()),signal);
 
-     if ( result == 0 )
-     {
-         _shellProcess->waitForFinished();
-         return true;
-     }
-     else
-         return false;
+    if ( result == 0 )
+    {
+        _shellProcess->waitForFinished();
+        return true;
+    }
+
+    return false;
 }
 
 void Session::close()
@@ -556,7 +519,7 @@ void Session::close()
     _wantedClose = true;
     if (!_shellProcess->isRunning() || !sendSignal(SIGHUP)) {
         // Forced close.
-        QTimer::singleShot(1, this, SIGNAL(finished()));
+        QTimer::singleShot(1, this, &Session::finished);
     }
 }
 
@@ -1041,8 +1004,7 @@ void SessionGroup::connectPair(Session * master , Session * other) const
     if ( _masterMode & CopyInputToAll ) {
         qDebug() << "Connection session " << master->nameTitle() << "to" << other->nameTitle();
 
-        connect( master->emulation() , SIGNAL(sendData(const char *,int)) , other->emulation() ,
-                 SLOT(sendString(const char *,int)) );
+        connect(master->emulation(), &Emulation::sendData, other->emulation(), &Emulation::sendString);
     }
 }
 void SessionGroup::disconnectPair(Session * master , Session * other) const
@@ -1052,8 +1014,7 @@ void SessionGroup::disconnectPair(Session * master , Session * other) const
     if ( _masterMode & CopyInputToAll ) {
         qDebug() << "Disconnecting session " << master->nameTitle() << "from" << other->nameTitle();
 
-        disconnect( master->emulation() , SIGNAL(sendData(const char *,int)) , other->emulation() ,
-                    SLOT(sendString(const char *,int)) );
+        disconnect(master->emulation(), &Emulation::sendData, other->emulation(), &Emulation::sendString);
     }
 }
 

--- a/lib/Session.h
+++ b/lib/Session.h
@@ -491,7 +491,11 @@ signals:
 private slots:
     void done(int);
 
-//  void fireZModemDetected();
+private:
+
+    void updateTerminalSize();
+    WId windowId() const;
+    //  void fireZModemDetected();
 
     void onReceiveBlock( const char * buffer, int len );
     void monitorTimerDone();
@@ -504,32 +508,28 @@ private slots:
     //automatically detach views from sessions when view is destroyed
     void viewDestroyed(QObject * view);
 
-//  void zmodemReadStatus();
-//  void zmodemReadAndSendBlock();
-//  void zmodemRcvBlock(const char *data, int len);
-//  void zmodemFinished();
+    //  void zmodemReadStatus();
+    //  void zmodemReadAndSendBlock();
+    //  void zmodemRcvBlock(const char *data, int len);
+    //  void zmodemFinished();
 
-private:
-
-    void updateTerminalSize();
-    WId windowId() const;
 
     int            _uniqueIdentifier;
 
-    Pty     *_shellProcess;
-    Emulation  *  _emulation;
+    Pty     *_shellProcess = nullptr;
+    Emulation  *  _emulation = nullptr;
 
     QList<TerminalDisplay *> _views;
 
-    bool           _monitorActivity;
-    bool           _monitorSilence;
-    bool           _notifiedActivity;
+    bool           _monitorActivity = false;
+    bool           _monitorSilence = false;
+    bool           _notifiedActivity = false;
     bool           _masterMode;
-    bool           _autoClose;
-    bool           _wantedClose;
+    bool           _autoClose = true;
+    bool           _wantedClose = true;
     QTimer    *    _monitorTimer;
 
-    int            _silenceSeconds;
+    int            _silenceSeconds = 10;
 
     QString        _nameTitle;
     QString        _displayTitle;
@@ -540,8 +540,15 @@ private:
 
     QString        _iconName;
     QString        _iconText; // as set by: echo -en '\033]1;IconText\007
-    bool           _isTitleChanged; ///< flag if the title/icon was changed by user
-    bool           _addToUtmp;
+    bool           _isTitleChanged = false; ///< flag if the title/icon was changed by user
+
+    /* Disabled by default because of a bug encountered on certain systems
+     * which caused Konsole to hang when closing a tab and then opening a new
+     * one.  A 'QProcess destroyed while still running' warning was being
+     * printed to the terminal.  Likely a problem in KPty::logout()
+     * or KPty::login() which uses a QProcess to start /usr/bin/utempter
+     */
+    bool           _addToUtmp = false;
     bool           _flowControl;
     bool           _fullScripting;
 

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -569,9 +569,9 @@ signals:
    void sendStringToEmu(const char*);
 
    // qtermwidget signals
-	void copyAvailable(bool);
-	void termGetFocus();
-	void termLostFocus();
+   void copyAvailable(bool);
+   void termGetFocus();
+   void termLostFocus();
 
     void notifyBell(const QString&);
     void usesMouseChanged();
@@ -725,118 +725,118 @@ private:
     // is currently showing.
     QPointer<ScreenWindow> _screenWindow;
 
-    bool _allowBell;
+    bool _allowBell = true;
 
-    QGridLayout* _gridLayout;
+    QGridLayout* _gridLayout = nullptr;
 
     bool _fixedFont; // has fixed pitch
-    int  _fontHeight;     // height
-    int  _fontWidth;     // width
-    int  _fontAscent;     // ascend
-    bool _boldIntense;   // Whether intense colors should be rendered with bold font
-    int  _drawTextAdditionHeight;   // additional height to prevent font trancation
-    bool _drawTextTestFlag;         // indicate it is a testing or not
+    int  _fontHeight = 1;     // height
+    int  _fontWidth = 1;     // width
+    int  _fontAscent = 1;     // ascend
+    bool _boldIntense = true;   // Whether intense colors should be rendered with bold font
+    int  _drawTextAdditionHeight = 0;   // additional height to prevent font trancation
+    bool _drawTextTestFlag = false;         // indicate it is a testing or not
 
     int _leftMargin;    // offset
     int _topMargin;    // offset
 
-    int _lines;      // the number of lines that can be displayed in the widget
-    int _columns;    // the number of columns that can be displayed in the widget
+    int _lines = 1;      // the number of lines that can be displayed in the widget
+    int _columns = 1;    // the number of columns that can be displayed in the widget
 
-    int _usedLines;  // the number of lines that are actually being used, this will be less
+    int _usedLines = 1;  // the number of lines that are actually being used, this will be less
                     // than 'lines' if the character image provided with setImage() is smaller
                     // than the maximum image size which can be displayed
 
-    int _usedColumns; // the number of columns that are actually being used, this will be less
+    int _usedColumns = 1; // the number of columns that are actually being used, this will be less
                      // than 'columns' if the character image provided with setImage() is smaller
                      // than the maximum image size which can be displayed
 
-    int _contentHeight;
-    int _contentWidth;
-    Character* _image; // [lines][columns]
+    int _contentHeight = 1;
+    int _contentWidth = 1;
+    Character* _image = nullptr; // [lines][columns]
                // only the area [usedLines][usedColumns] in the image contains valid data
 
     int _imageSize;
     QVector<LineProperty> _lineProperties;
 
     ColorEntry _colorTable[TABLE_COLORS];
-    uint _randomSeed;
+    uint _randomSeed = 0U;
 
-    bool _resizing;
-    bool _terminalSizeHint;
-    bool _terminalSizeStartup;
-    bool _bidiEnabled;
-    bool _mouseMarks;
+    bool _resizing = false;
+    bool _terminalSizeHint = false;
+    bool _terminalSizeStartup = true;
+    bool _bidiEnabled = false;
+    bool _mouseMarks = false;
     bool _bracketedPasteMode;
-    bool _disabledBracketedPasteMode;
+    bool _disabledBracketedPasteMode = false;
 
     QPoint  _iPntSel; // initial selection point
     QPoint  _pntSel; // current selection point
     QPoint  _tripleSelBegin; // help avoid flicker
-    int     _actSel; // selection state
-    bool    _wordSelectionMode;
-    bool    _lineSelectionMode;
-    bool    _preserveLineBreaks;
-    bool    _columnSelectionMode;
+    int     _actSel = 0; // selection state
+    bool    _wordSelectionMode = false;
+    bool    _lineSelectionMode = false;
+    bool    _preserveLineBreaks = false;
+    bool    _columnSelectionMode = false;
 
     QClipboard*  _clipboard;
     QScrollBar* _scrollBar;
-    QTermWidget::ScrollBarPosition _scrollbarLocation;
-    QString     _wordCharacters;
-    int         _bellMode;
+    QTermWidget::ScrollBarPosition _scrollbarLocation = QTermWidget::ScrollBarPosition::NoScrollBar;
+    QString     _wordCharacters = QLatin1String(":@-./_~");
+    int         _bellMode = SystemBeepBell;
 
-    bool _blinking;   // hide text in paintEvent
-    bool _hasBlinker; // has characters to blink
-    bool _cursorBlinking;     // hide cursor in paintEvent
-    bool _hasBlinkingCursor;  // has blinking cursor enabled
-    bool _allowBlinkingText;  // allow text to blink
-    bool _ctrlDrag;           // require Ctrl key for drag
-    TripleClickMode _tripleClickMode;
-    bool _isFixedSize; //Columns / lines are locked.
-    QTimer* _blinkTimer;  // active when hasBlinker
-    QTimer* _blinkCursorTimer;  // active when hasBlinkingCursor
+    bool _blinking = false;   // hide text in paintEvent
+    bool _hasBlinker = false; // has characters to blink
+    bool _cursorBlinking = false;     // hide cursor in paintEvent
+    bool _hasBlinkingCursor = false;  // has blinking cursor enabled
+    bool _allowBlinkingText = true;  // allow text to blink
+    bool _ctrlDrag = false;           // require Ctrl key for drag
+    TripleClickMode _tripleClickMode = SelectWholeLine;
+    bool _isFixedSize = false; //Columns / lines are locked.
+    QTimer* _blinkTimer = nullptr;  // active when hasBlinker
+    QTimer* _blinkCursorTimer = nullptr;  // active when hasBlinkingCursor
 
     //QMenu* _drop;
     QString _dropText;
     int _dndFileCount;
 
-    bool _possibleTripleClick;  // is set in mouseDoubleClickEvent and deleted
+    bool _possibleTripleClick = false;  // is set in mouseDoubleClickEvent and deleted
                                // after QApplication::doubleClickInterval() delay
 
 
-    QLabel* _resizeWidget;
-    QTimer* _resizeTimer;
+    QLabel* _resizeWidget = nullptr;
+    QTimer* _resizeTimer = nullptr;
 
-    bool _flowControlWarningEnabled;
+    bool _flowControlWarningEnabled = false;
 
     //widgets related to the warning message that appears when the user presses Ctrl+S to suspend
     //terminal output - informing them what has happened and how to resume output
-    QLabel* _outputSuspendedLabel;
+    QLabel* _outputSuspendedLabel = nullptr;
 
-    uint _lineSpacing;
+    uint _lineSpacing = 0U;
 
-    bool _colorsInverted; // true during visual bell
+    bool _colorsInverted = false; // true during visual bell
 
     QSize _size;
 
-    qreal _opacity;
+    qreal _opacity = 1;
 
     QPixmap _backgroundImage;
-    BackgroundMode _backgroundMode;
+    BackgroundMode _backgroundMode = None;
 
     // list of filters currently applied to the display.  used for links and
     // search highlight
-    TerminalImageFilterChain* _filterChain;
+    TerminalImageFilterChain* _filterChain = nullptr;
     QRegion _mouseOverHotspotArea;
 
-    QTermWidget::KeyboardCursorShape _cursorShape;
+    QTermWidget::KeyboardCursorShape _cursorShape = Emulation::KeyboardCursorShape::BlockCursor;
 
     // custom cursor color.  if this is invalid then the foreground
     // color of the character under the cursor is used
     QColor _cursorColor;
 
 
-    MotionAfterPasting mMotionAfterPasting;
+    MotionAfterPasting mMotionAfterPasting = NoMoveScreenWindow;
     bool _confirmMultilinePaste;
     bool _trimPastedTrailingNewlines;
 
@@ -852,10 +852,10 @@ private:
     //the delay in milliseconds between redrawing blinking text
     static const int TEXT_BLINK_DELAY = 500;
 
-    int _leftBaseMargin;
-    int _topBaseMargin;
+    int _leftBaseMargin = 1;
+    int _topBaseMargin = 1;
 
-    bool _drawLineChars;
+    bool _drawLineChars = true;
 
 public:
     static void setTransparencyEnabled(bool enable)

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -69,7 +69,7 @@ Vt102Emulation::Vt102Emulation()
   QObject::connect(_titleUpdateTimer , SIGNAL(timeout()) , this , SLOT(updateTitle()));
 
   initTokenizer();
-  reset();
+  Vt102Emulation::reset();
 }
 
 Vt102Emulation::~Vt102Emulation()

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -61,19 +61,14 @@ using namespace Konsole;
 
 Vt102Emulation::Vt102Emulation()
     : Emulation(),
-     prevCC(0),
-     _titleUpdateTimer(new QTimer(this)),
-     _reportFocusEvents(false)
+     _titleUpdateTimer(new QTimer(this))
 {
   _titleUpdateTimer->setSingleShot(true);
-  QObject::connect(_titleUpdateTimer , SIGNAL(timeout()) , this , SLOT(updateTitle()));
+  connect(_titleUpdateTimer, &QTimer::timeout, this, &Vt102Emulation::updateTitle);
 
   initTokenizer();
   Vt102Emulation::reset();
 }
-
-Vt102Emulation::~Vt102Emulation()
-{}
 
 void Vt102Emulation::clearEntireScreen()
 {

--- a/lib/Vt102Emulation.h
+++ b/lib/Vt102Emulation.h
@@ -82,7 +82,7 @@ Q_OBJECT
 public:
   /** Constructs a new emulation */
   Vt102Emulation();
-  ~Vt102Emulation() override;
+  ~Vt102Emulation() override = default;
 
   // reimplemented from Emulation
   void clearEntireScreen() override;
@@ -143,7 +143,7 @@ private:
   int argv[MAXARGS];
   int argc;
   void initTokenizer();
-  int prevCC;
+  int prevCC = 0;
 
   // Set of flags for each of the ASCII characters which indicates
   // what category they fall into (printable character, control, digit etc.)
@@ -191,9 +191,9 @@ private:
   //these calls occur when certain escape sequences are seen in the
   //output from the terminal
   QHash<int,QString> _pendingTitleUpdates;
-  QTimer* _titleUpdateTimer;
+  QTimer* _titleUpdateTimer = nullptr;
 
-    bool _reportFocusEvents;
+    bool _reportFocusEvents = false;
 };
 
 }

--- a/lib/kptydevice.cpp
+++ b/lib/kptydevice.cpp
@@ -294,7 +294,7 @@ KPtyDevice::KPtyDevice(QObject *parent) :
 
 KPtyDevice::~KPtyDevice()
 {
-    close();
+   KPtyDevice::close();
 }
 
 bool KPtyDevice::open(OpenMode mode)

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -315,30 +315,27 @@ public slots:
 protected:
     void resizeEvent(QResizeEvent *) override;
 
-protected slots:
-    void sessionFinished();
-    void selectionChanged(bool textSelected);
-
-private slots:
+private:
+    void search(bool forwards, bool next);
+    void setZoom(int step);
+    void init(int startnow);
     void find();
     void findNext();
     void findPrevious();
     void matchFound(int startColumn, int startLine, int endColumn, int endLine);
     void noMatchFound();
+    void sessionFinished();
+    void selectionChanged(bool textSelected);
     /**
      * Emulation::cursorChanged() signal propogates to here and QTermWidget
      * sends the specified cursor states to the terminal display
      */
-    void cursorChanged(Konsole::Emulation::KeyboardCursorShape cursorShape, bool blinkingCursorEnabled);
+    void onCursorChanged(Konsole::Emulation::KeyboardCursorShape cursorShape, bool blinkingCursorEnabled);
 
-private:
-    void search(bool forwards, bool next);
-    void setZoom(int step);
-    void init(int startnow);
-    TermWidgetImpl * m_impl;
-    SearchBar* m_searchBar;
-    QVBoxLayout *m_layout;
-    QTranslator *m_translator;
+    TermWidgetImpl * m_impl = nullptr;
+    SearchBar* m_searchBar = nullptr;
+    QVBoxLayout *m_layout = nullptr;
+    QTranslator *m_translator = nullptr;
 };
 
 


### PR DESCRIPTION
In this PR I've applied two main changes:

1. Use of Qt5 connects that will cause compilation error if the signal/slot doesn't exist or has a mismatch. This prevents connection problems in runtime, quite hard to debug/spot.
2. Move the initialization of member parameters to the header file. The reason for this is that in the case of having multiple constructors, one might forget to initialize some of the parameters, or if not forgotten, it will cause a lot of code duplication.

These should be harmless modifications since they don't change any implementation.

I've postponed some _real changes_ like using smart pointers, modern iterators, etc. until this PR goes in and clang-format is in place. I don't think it's recommendable to modify everything in one single PR.

Last thing: I've kept one old-style connect because it would make the code use [qoverload](https://doc.qt.io/qt-5/qtglobal.html#qOverload). I know that this was an issue in some distros as ArchLinux and since I'm not sure QTermWidget is ship there or not, I decided to keep it.