### PR TITLE
Made DND text follow settings for newline trimming and multiline prompt

### DIFF
--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -697,6 +697,9 @@ private:
     // the left and right are ignored.
     void scrollImage(int lines , const QRect& region);
 
+    // shows the multiline prompt
+    bool multilineConfirmation(const QString& text);
+
     void calcGeometry();
     void propagateSize();
     void updateImageSize();


### PR DESCRIPTION
Fixes https://github.com/lxqt/qterminal/issues/970 and fixes https://github.com/lxqt/qterminal/issues/652

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

