### PR TITLE
Add getForegroundProcessId() function to QTermWidget class

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ enum | KeyboardCursorShape { BlockCursor, UnderlineCursor, IBeamCursor }
 * flowControlEnabled : bool
 * getPtySlaveFd : const int
 * getShellPID : int
+* getForegroundProcessId : int
 * getTerminalFont : QFont
 * historyLinesCount : int
 * icon : const QString
@@ -204,6 +205,11 @@ Returns whether flow control is enabled.
 Returns a pty slave file descriptor. This can be used for display and control a remote terminal.
 
 <!--**getShellPID : int**\-->
+**getForegroundProcessId : int**\
+Returns the PID of the foreground process. This is initially the same as processId() but can change
+as the user starts other programs inside the terminal. If there is a problem reading the foreground
+process id, 0 will be returned.
+
 <!--**getTerminalFont : QFont**\-->
 
 **historyLinesCount : int**\

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -201,6 +201,11 @@ int QTermWidget::getShellPID()
     return m_impl->m_session->processId();
 }
 
+int QTermWidget::getForegroundProcessId()
+{
+    return m_impl->m_session->foregroundProcessId();
+}
+
 void QTermWidget::changeDir(const QString & dir)
 {
     /*

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -69,6 +69,11 @@ public:
 
     int getShellPID() override;
 
+    /**
+     * Get the PID of the foreground process
+     */
+    int getForegroundProcessId() override;
+
     void changeDir(const QString & dir) override;
 
     //look-n-feel, if you don`t like defaults
@@ -353,4 +358,3 @@ extern "C"
 void * createTermWidget(int startnow, void * parent);
 
 #endif
-

--- a/lib/qtermwidget_interface.h
+++ b/lib/qtermwidget_interface.h
@@ -44,6 +44,7 @@ class QTermWidgetInterface {
    virtual void startShellProgram() = 0;
    virtual void startTerminalTeletype() = 0;
    virtual int getShellPID() = 0;
+   virtual int getForegroundProcessId() = 0;
    virtual void changeDir(const QString & dir) = 0;
    virtual void setTerminalFont(const QFont & font) = 0;
    virtual QFont getTerminalFont() = 0;

--- a/pyqt/sip/qtermwidget.sip
+++ b/pyqt/sip/qtermwidget.sip
@@ -37,6 +37,7 @@ public:
     bool terminalSizeHint();
     void startShellProgram();
     int getShellPID();
+    int getForegroundProcessId();
     void changeDir(const QString & dir);
     void setTerminalFont(QFont &font);
     QFont getTerminalFont();


### PR DESCRIPTION
This will allow terminal apps to check if the user has started a process in the shell and alert them.