### PR TITLE
Misc downstream fixes from QGIS

### DIFF
--- a/lib/BlockArray.h
+++ b/lib/BlockArray.h
@@ -33,11 +33,8 @@
 namespace Konsole {
 
 struct Block {
-    Block() {
-        size = 0;
-    }
-    unsigned char data[ENTRIES];
-    size_t size;
+    unsigned char data[ENTRIES] = {};
+    size_t size = 0;
 };
 
 // ///////////////////////////////////////////////////////

--- a/lib/BlockArray.h
+++ b/lib/BlockArray.h
@@ -28,7 +28,7 @@
 //#error Do not use in KDE 2.1
 
 #define QTERMWIDGET_BLOCKSIZE (1 << 12)
-#define ENTRIES   ((QTERMWIDGET_BLOCKSIZE - sizeof(size_t) ) / sizeof(unsigned char))
+#define ENTRIES   (QTERMWIDGET_BLOCKSIZE - sizeof(size_t))
 
 namespace Konsole {
 

--- a/lib/ColorScheme.cpp
+++ b/lib/ColorScheme.cpp
@@ -417,9 +417,9 @@ void ColorScheme::writeColorEntry(KConfig& config , const QString& colorName, co
     // if one of the keys already exists
     if ( !random.isNull() || configGroup.hasKey("MaxRandomHue") )
     {
-        configGroup.writeEntry("MaxRandomHue",(int)random.hue);
-        configGroup.writeEntry("MaxRandomValue",(int)random.value);
-        configGroup.writeEntry("MaxRandomSaturation",(int)random.saturation);
+        configGroup.writeEntry("MaxRandomHue",static_cast<int>(random.hue));
+        configGroup.writeEntry("MaxRandomValue",static_cast<int>(random.value));
+        configGroup.writeEntry("MaxRandomSaturation",static_cast<int>(random.saturation));
     }
 }
 #endif

--- a/lib/ColorScheme.h
+++ b/lib/ColorScheme.h
@@ -200,6 +200,8 @@ private:
     static const char* const translatedColorNames[TABLE_COLORS];
 
     static const ColorEntry defaultTable[]; // table of default color entries
+
+    ColorScheme& operator=(const ColorScheme&) = delete;
 };
 
 /**

--- a/lib/Filter.h
+++ b/lib/Filter.h
@@ -275,6 +275,9 @@ public:
         UrlType urlType() const;
 
         FilterObject* _urlObject;
+
+        HotSpot( const HotSpot& ) = delete;
+        HotSpot& operator= ( const HotSpot& ) = delete;
     };
 
     UrlFilter();

--- a/lib/History.cpp
+++ b/lib/History.cpp
@@ -385,12 +385,12 @@ void HistoryScrollBuffer::setMaxNbLines(unsigned int lineCount)
     HistoryLine* oldBuffer = _historyBuffer;
     HistoryLine* newBuffer = new HistoryLine[lineCount];
 
-    for ( int i = 0 ; i < qMin(_usedLines,(int)lineCount) ; i++ )
+    for ( int i = 0 ; i < qMin(_usedLines,static_cast<int>(lineCount)) ; i++ )
     {
         newBuffer[i] = oldBuffer[bufferIndex(i)];
     }
 
-    _usedLines = qMin(_usedLines,(int)lineCount);
+    _usedLines = qMin(_usedLines,static_cast<int>(lineCount));
     _maxLineCount = lineCount;
     _head = ( _usedLines == _maxLineCount ) ? 0 : _usedLines-1;
 
@@ -770,7 +770,7 @@ void CompactHistoryScroll::setMaxNbLines ( unsigned int lineCount )
 {
   _maxLineCount = lineCount;
 
-  while (lines.size() > (int) lineCount) {
+  while (lines.size() > static_cast<int>(lineCount)) {
     delete lines.takeAt(0);
   }
   //kDebug() << "set max lines to: " << _maxLineCount;
@@ -872,7 +872,7 @@ HistoryScroll* HistoryTypeBuffer::scroll(HistoryScroll *old) const
     HistoryScroll *newScroll = new HistoryScrollBuffer(m_nbLines);
     int lines = old->getLines();
     int startLine = 0;
-    if (lines > (int) m_nbLines)
+    if (lines > static_cast<int>(m_nbLines))
        startLine = lines - m_nbLines;
 
     Character line[LINE_SIZE];

--- a/lib/History.cpp
+++ b/lib/History.cpp
@@ -127,7 +127,7 @@ void HistoryFile::map()
 void HistoryFile::unmap()
 {
     int result = munmap( fileMap , length );
-    Q_ASSERT( result == 0 ); Q_UNUSED( result );
+    Q_ASSERT( result == 0 ); Q_UNUSED( result )
 
     fileMap = nullptr;
 }
@@ -523,7 +523,7 @@ void HistoryScrollBlockArray::addCells(const Character a[], int count)
 
   size_t res = m_blockArray.newBlock();
   Q_ASSERT(res > 0);
-  Q_UNUSED( res );
+  Q_UNUSED( res )
 
   m_lineLengths.insert(m_blockArray.getCurrent(), count);
 }

--- a/lib/History.h
+++ b/lib/History.h
@@ -122,7 +122,7 @@ public:
   // is very unsafe, because those references will no longer
   // be valid if the history scroll is deleted.
   //
-  const HistoryType& getType() { return *m_histType; }
+  const HistoryType& getType() const { return *m_histType; }
 
 protected:
   HistoryType* m_histType;

--- a/lib/History.h
+++ b/lib/History.h
@@ -75,7 +75,7 @@ private:
   //'get' is called.
   //this is used to detect when a large number of lines are being read and processed from the history
   //and automatically mmap the file for better performance (saves the overhead of many lseek-read calls).
-  int readWriteBalance;
+  int readWriteBalance = 0;
 
   //when readWriteBalance goes below this threshold, the file will be mmap'ed automatically
   static const int MAP_THRESHOLD = -1000;

--- a/lib/HistorySearch.h
+++ b/lib/HistorySearch.h
@@ -56,14 +56,14 @@ private:
 
     EmulationPtr m_emulation;
     QRegExp m_regExp;
-    bool m_forwards;
-    int m_startColumn;
-    int m_startLine;
+    bool m_forwards = false;
+    int m_startColumn = 0;
+    int m_startLine = 0;
 
-    int m_foundStartColumn;
-    int m_foundStartLine;
-    int m_foundEndColumn;
-    int m_foundEndLine;
+    int m_foundStartColumn = 0;
+    int m_foundStartLine = 0;
+    int m_foundEndColumn = 0;
+    int m_foundEndLine = 0;
 };
 
 #endif	/* TASK_H */

--- a/lib/KeyboardTranslator.cpp
+++ b/lib/KeyboardTranslator.cpp
@@ -120,7 +120,7 @@ const KeyboardTranslator* KeyboardTranslatorManager::findTranslator(const QStrin
 bool KeyboardTranslatorManager::saveTranslator(const KeyboardTranslator* translator)
 {
 qDebug() << "KeyboardTranslatorManager::saveTranslator" << "unimplemented";
-Q_UNUSED(translator);
+Q_UNUSED(translator)
 #if 0
     const QString path = KGlobal::dirs()->saveLocation("data","konsole/")+translator->name()
            +".keytab";

--- a/lib/KeyboardTranslator.h
+++ b/lib/KeyboardTranslator.h
@@ -420,6 +420,9 @@ private:
     QString _description;
     KeyboardTranslator::Entry _nextEntry;
     bool _hasNext;
+
+    KeyboardTranslatorReader(const KeyboardTranslatorReader&) = delete;
+    KeyboardTranslatorReader& operator=(const KeyboardTranslatorReader&) = delete;
 };
 
 /** Writes a keyboard translation to disk. */
@@ -444,6 +447,9 @@ public:
 private:
     QIODevice* _destination;
     QTextStream* _writer;
+
+    KeyboardTranslatorWriter(const KeyboardTranslatorWriter&) = delete;
+    KeyboardTranslatorWriter& operator=(const KeyboardTranslatorWriter&) = delete;
 };
 
 /**

--- a/lib/Pty.cpp
+++ b/lib/Pty.cpp
@@ -297,7 +297,7 @@ void Pty::dataReceived()
 
 void Pty::lockPty(bool lock)
 {
-    Q_UNUSED(lock);
+    Q_UNUSED(lock)
 
 // TODO: Support for locking the Pty
   //if (lock)

--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -515,7 +515,7 @@ void Screen::getImage( Character* dest, int size, int startLine, int endLine ) c
     const int mergedLines = endLine - startLine + 1;
 
     Q_ASSERT( size >= mergedLines * columns );
-    Q_UNUSED( size );
+    Q_UNUSED( size )
 
     const int linesInHistoryBuffer = qBound(0,history->getLines()-startLine,mergedLines);
     const int linesInScreenBuffer = mergedLines - linesInHistoryBuffer;

--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -455,6 +455,7 @@ void Screen::updateEffectiveRendition()
 
 void Screen::copyFromHistory(Character* dest, int startLine, int count) const
 {
+    // cppcheck-suppress assertWithSideEffect
     Q_ASSERT( startLine >= 0 && count > 0 && startLine + count <= history->getLines() );
 
     for (int line = startLine; line < startLine + count; line++)
@@ -508,6 +509,7 @@ void Screen::copyFromScreen(Character* dest , int startLine , int count) const
 void Screen::getImage( Character* dest, int size, int startLine, int endLine ) const
 {
     Q_ASSERT( startLine >= 0 );
+    // cppcheck-suppress assertWithSideEffect
     Q_ASSERT( endLine >= startLine && endLine < history->getLines() + lines );
 
     const int mergedLines = endLine - startLine + 1;
@@ -544,6 +546,7 @@ void Screen::getImage( Character* dest, int size, int startLine, int endLine ) c
 QVector<LineProperty> Screen::getLineProperties( int startLine , int endLine ) const
 {
     Q_ASSERT( startLine >= 0 );
+    // cppcheck-suppress assertWithSideEffect
     Q_ASSERT( endLine >= startLine && endLine < history->getLines() + lines );
 
     const int mergedLines = endLine-startLine+1;
@@ -1263,6 +1266,7 @@ int Screen::copyLineToStream(int line ,
         // safety checks
         Q_ASSERT( start >= 0 );
         Q_ASSERT( count >= 0 );
+        // cppcheck-suppress assertWithSideEffect
         Q_ASSERT( (start+count) <= history->getLineLen(line) );
 
         history->getCells(line,start,count,characterBuffer);

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -688,6 +688,7 @@ private:
     unsigned short lastDrawnChar;
 
     static Character defaultChar;
+
 };
 
 }

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -112,7 +112,7 @@ Session::Session(QObject* parent) :
     connect( _emulation,SIGNAL(lockPtyRequest(bool)),_shellProcess,SLOT(lockPty(bool)) );
     connect( _emulation,SIGNAL(useUtf8Request(bool)),_shellProcess,SLOT(setUtf8Mode(bool)) );
 
-    connect( _shellProcess,SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(done(int)) );
+    connect( _shellProcess,SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(done(int,QProcess::ExitStatus)) );
     // not in kprocess anymore connect( _shellProcess,SIGNAL(done(int)), this, SLOT(done(int)) );
 
     //setup timer for monitoring session activity
@@ -587,7 +587,7 @@ QString Session::profileKey() const
     return _profileKey;
 }
 
-void Session::done(int exitStatus)
+void Session::done(int exitCode, QProcess::ExitStatus exitStatus)
 {
     if (!_autoClose) {
         _userTitle = QString::fromLatin1("This session is done. Finished");
@@ -600,16 +600,16 @@ void Session::done(int exitStatus)
     // So, we make it translatable, hoping that in the future it will
     // be used in some kind of notification.
     QString message;
-    if (!_wantedClose || exitStatus != 0) {
+    if (!_wantedClose || exitCode != 0) {
 
         if (_shellProcess->exitStatus() == QProcess::NormalExit) {
-            message = tr("Session '%1' exited with status %2.").arg(_nameTitle).arg(exitStatus);
+            message = tr("Session '%1' exited with code %2.").arg(_nameTitle).arg(exitCode);
         } else {
             message = tr("Session '%1' crashed.").arg(_nameTitle);
         }
     }
 
-    if ( !_wantedClose && _shellProcess->exitStatus() != QProcess::NormalExit )
+    if ( !_wantedClose && exitStatus != QProcess::NormalExit )
         message = tr("Session '%1' exited unexpectedly.").arg(_nameTitle);
     else
         emit finished();

--- a/lib/Session.h
+++ b/lib/Session.h
@@ -25,6 +25,7 @@
 #ifndef SESSION_H
 #define SESSION_H
 
+#include <QProcess>
 #include <QStringList>
 #include <QWidget>
 
@@ -489,7 +490,7 @@ signals:
     void activity();
 
 private slots:
-    void done(int);
+    void done(int, QProcess::ExitStatus );
 
 //  void fireZModemDetected();
 

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2016,7 +2016,7 @@ void TerminalDisplay::mousePressEvent(QMouseEvent* ev)
           spot->activate(QLatin1String("click-action"));
     }
   }
-  else if ( ev->button() == Qt::MidButton )
+  else if ( ev->button() == Qt::MiddleButton )
   {
     if ( _mouseMarks || (ev->modifiers() & Qt::ShiftModifier) )
       emitSelection(true,ev->modifiers() & Qt::ControlModifier);
@@ -2107,7 +2107,7 @@ void TerminalDisplay::mouseMoveEvent(QMouseEvent* ev)
     int button = 3;
     if (ev->buttons() & Qt::LeftButton)
         button = 0;
-    if (ev->buttons() & Qt::MidButton)
+    if (ev->buttons() & Qt::MiddleButton)
         button = 1;
     if (ev->buttons() & Qt::RightButton)
         button = 2;
@@ -2149,7 +2149,7 @@ void TerminalDisplay::mouseMoveEvent(QMouseEvent* ev)
   if (_actSel == 0) return;
 
  // don't extend selection while pasting
-  if (ev->buttons() & Qt::MidButton) return;
+  if (ev->buttons() & Qt::MiddleButton) return;
 
   extendSelection( ev->pos() );
 }
@@ -2404,9 +2404,9 @@ void TerminalDisplay::mouseReleaseEvent(QMouseEvent* ev)
 
   if ( !_mouseMarks &&
        ((ev->button() == Qt::RightButton && !(ev->modifiers() & Qt::ShiftModifier))
-                        || ev->button() == Qt::MidButton) )
+                        || ev->button() == Qt::MiddleButton) )
   {
-    emit mouseSignal( ev->button() == Qt::MidButton ? 1 : 2,
+    emit mouseSignal( ev->button() == Qt::MiddleButton ? 1 : 2,
                       charColumn + 1,
                       charLine + 1 +_scrollBar->value() -_scrollBar->maximum() ,
                       2);

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -226,7 +226,7 @@ void TerminalDisplay::fontChange(const QFont&)
   // "Base character width on widest ASCII character. This prevents too wide
   //  characters in the presence of double wide (e.g. Japanese) characters."
   // Get the width from representative normal width characters
-  _fontWidth = qRound((double)fm.horizontalAdvance(QLatin1String(REPCHAR))/(double)qstrlen(REPCHAR));
+  _fontWidth = qRound(static_cast<double>(fm.horizontalAdvance(QLatin1String(REPCHAR)))/static_cast<double>(qstrlen(REPCHAR)));
 
   _fixedFont = true;
 

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -3331,7 +3331,7 @@ void AutoScrollHandler::timerEvent(QTimerEvent* event)
 bool AutoScrollHandler::eventFilter(QObject* watched,QEvent* event)
 {
     Q_ASSERT( watched == parent() );
-    Q_UNUSED( watched );
+    Q_UNUSED( watched )
 
     QMouseEvent* mouseEvent = (QMouseEvent*)event;
     switch (event->type())

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2903,7 +2903,7 @@ QVariant TerminalDisplay::inputMethodQuery( Qt::InputMethodQuery query ) const
     const QPoint cursorPos = _screenWindow ? _screenWindow->cursorPosition() : QPoint(0,0);
     switch ( query )
     {
-        case Qt::ImMicroFocus:
+        case Qt::ImCursorRectangle:
                 return imageToWidget(QRect(cursorPos.x(),cursorPos.y(),1,1));
             break;
         case Qt::ImFont:

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -154,7 +154,7 @@ void Vt102Emulation::reset()
 
 */
 
-#define TY_CONSTRUCT(T,A,N) ( ((((int)N) & 0xffff) << 16) | ((((int)A) & 0xff) << 8) | (((int)T) & 0xff) )
+#define TY_CONSTRUCT(T,A,N) ( (((static_cast<int>(N)) & 0xffff) << 16) | (((static_cast<int>(A)) & 0xff) << 8) | ((static_cast<int>(T)) & 0xff) )
 
 #define TY_CHR(   )     TY_CONSTRUCT(0,0,0)
 #define TY_CTL(A  )     TY_CONSTRUCT(1,A,0)

--- a/lib/kprocess.cpp
+++ b/lib/kprocess.cpp
@@ -88,7 +88,7 @@ void KProcessPrivate::_k_forwardStdout()
 #ifndef _WIN32_WCE
     forwardStd(KProcess::StandardOutput, STD_OUTPUT_HANDLE);
 #else
-    forwardStd(KProcess::StandardOutput, (int)stdout);
+    forwardStd(KProcess::StandardOutput, static_cast<int>(stdout));
 #endif
 }
 
@@ -97,7 +97,7 @@ void KProcessPrivate::_k_forwardStderr()
 #ifndef _WIN32_WCE
     forwardStd(KProcess::StandardError, STD_ERROR_HANDLE);
 #else
-    forwardStd(KProcess::StandardError, (int)stderr);
+    forwardStd(KProcess::StandardError, static_cast<int>(stderr));
 #endif
 }
 

--- a/lib/kprocess.h
+++ b/lib/kprocess.h
@@ -353,10 +353,10 @@ protected:
 
     QString prog;
     QStringList args;
-    KProcess::OutputChannelMode outputChannelMode;
+    KProcess::OutputChannelMode outputChannelMode = KProcess::SeparateChannels; // arbitrary value
     QIODevice::OpenMode openMode;
 
-    KProcess *q_ptr;
+    KProcess *q_ptr = nullptr;
 };
 /* ------------------------------------------- */
 #endif

--- a/lib/kpty.cpp
+++ b/lib/kpty.cpp
@@ -513,7 +513,7 @@ void KPty::login(const char * user, const char * remotehost)
     Q_D(KPty);
 
     addToUtmp(d->ttyName.constData(), remotehost, d->masterFd);
-    Q_UNUSED(user);
+    Q_UNUSED(user)
 #else
 # ifdef HAVE_UTMPX
     struct utmpx l_struct;

--- a/lib/kpty.h
+++ b/lib/kpty.h
@@ -188,6 +188,7 @@ protected:
      * @internal
      */
     KPtyPrivate * const d_ptr;
+
 };
 
 #endif

--- a/lib/kptydevice.cpp
+++ b/lib/kptydevice.cpp
@@ -400,14 +400,14 @@ bool KPtyDevice::isSuspended() const
 qint64 KPtyDevice::readData(char *data, qint64 maxlen)
 {
     Q_D(KPtyDevice);
-    return d->readBuffer.read(data, (int)qMin<qint64>(maxlen, KMAXINT));
+    return d->readBuffer.read(data, static_cast<int>(qMin<qint64>(maxlen, KMAXINT)));
 }
 
 // protected
 qint64 KPtyDevice::readLineData(char *data, qint64 maxlen)
 {
     Q_D(KPtyDevice);
-    return d->readBuffer.readLine(data, (int)qMin<qint64>(maxlen, KMAXINT));
+    return d->readBuffer.readLine(data, static_cast<int>(qMin<qint64>(maxlen, KMAXINT)));
 }
 
 // protected

--- a/lib/kptyprocess.h
+++ b/lib/kptyprocess.h
@@ -169,7 +169,7 @@ public:
             pty->logout();
     }
 
-    KPtyDevice *pty;
+    KPtyDevice *pty = nullptr;
     KPtyProcess::PtyChannels ptyChannels;
     bool addUtmp : 1;
 };


### PR DESCRIPTION
This ports a number of fixes from the downstream QGIS project. They've been added downstream to keep compilation warning free and the various code analysis tools used in our workflows happy (cppcheck, coverity, clang-tidy).