### PR TITLE
Prevent crash under kwin_wayland

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2920,7 +2920,7 @@ QVariant TerminalDisplay::inputMethodQuery( Qt::InputMethodQuery query ) const
                 QTextStream stream(&lineText);
                 PlainTextDecoder decoder;
                 decoder.begin(&stream);
-                decoder.decodeLine(&_image[loc(0,cursorPos.y())],_usedColumns,_lineProperties[cursorPos.y()]);
+                decoder.decodeLine(&_image[loc(0,cursorPos.y())],_usedColumns,0);
                 decoder.end();
                 return lineText;
             }


### PR DESCRIPTION
On the one hand, `PlainTextDecoder::decodeLine()` doesn't use its last argument.

On the other hand, there is something wrong with handling of the private variable `_lineProperties` in `TerminalDisplay` because it may be used outside its range and cause a crash in `TerminalDisplay::inputMethodQuery()` under Wayland (see https://github.com/lxqt/qterminal/issues/1031).

Therefore, this patch removes it from `TerminalDisplay::inputMethodQuery()`.

Fixes https://github.com/lxqt/qterminal/issues/1031

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

