### PR TITLE
Generally build on FreeBSD with HAVE_UTEMPTER

### DIFF
--- a/lib/kpty.cpp
+++ b/lib/kpty.cpp
@@ -32,6 +32,10 @@
 #define HAVE_LIBUTIL_H
 #endif
 
+#if defined(__FreeBSD__)
+#define HAVE_UTEMPTER
+#endif
+
 #if defined(__OpenBSD__)
 #define HAVE_LOGIN
 #define HAVE_UTIL_H
@@ -97,6 +101,9 @@
 
 #ifdef HAVE_UTEMPTER
 extern "C" {
+# if defined(__FreeBSD__)
+#  include <ulog.h>
+# endif
 # include <utempter.h>
 }
 #else


### PR DESCRIPTION
When qtermwidget is used on FreeBSD as an internal version within third party software, e.g. in QGIS [1], it is not recognized that Therefore HAVE_UTEMPTER is generally set when FreeBSD is detected. Also, ulog.h is required on FreeBSD.

[1] https://github.com/qgis/QGIS/commit/d3770d32f6ac4aac83d32b29f2f08519afea2dda

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

