### PR TITLE
Init variable

### DIFF
--- a/lib/History.cpp
+++ b/lib/History.cpp
@@ -253,7 +253,7 @@ int HistoryScrollFile::startOfLine(int lineno)
     if (!index.isMapped())
             index.map();
 
-    int res;
+    int res = 0;
     index.get((unsigned char*)&res,sizeof(int),(lineno-1)*sizeof(int));
     return res;
     }


### PR DESCRIPTION
In same cases HistoryScrollFile::startOfLine() was returning garbage via
uninitialized res.
