### PR TITLE
Expose wordCharacters property to QTermWidget API

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ enum | KeyboardCursorShape { BlockCursor, UnderlineCursor, IBeamCursor }
 * sizeHint : const QSize
 * terminalSizeHint : bool
 * title : const QString
+* wordCharacters : QString
 * workingDirectory : QString
 
 ### Public Functions
@@ -229,6 +230,10 @@ Returns the currently selected text.
 <!--**terminalSizeHint : bool**\-->
 <!--**title : const QString**\-->
 <!--**workingDirectory : QString**\-->
+
+**wordCharacters : QString**\
+When selecting text by word, consider these characters to be word characters in addition to
+alphanumeric characters, default is `:@-./_~`.
 
 ### Member Function Documentation
 <!--__void activity()__\-->

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -826,6 +826,16 @@ void QTermWidget::setTrimPastedTrailingNewlines(bool trimPastedTrailingNewlines)
     m_impl->m_terminalDisplay->setTrimPastedTrailingNewlines(trimPastedTrailingNewlines);
 }
 
+QString QTermWidget::wordCharacters() const
+{
+    return m_impl->m_terminalDisplay->wordCharacters();
+}
+
+void QTermWidget::setWordCharacters(const QString& chars)
+{
+    m_impl->m_terminalDisplay->setWordCharacters(chars);
+}
+
 QTermWidgetInterface* QTermWidget::createWidget(int startnow) const
 {
    return new QTermWidget(startnow);

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -258,6 +258,9 @@ public:
     void setConfirmMultilinePaste(bool confirmMultilinePaste) override;
     void setTrimPastedTrailingNewlines(bool trimPastedTrailingNewlines) override;
 
+    QString wordCharacters() const override;
+    void setWordCharacters(const QString& chars) override;
+
     QTermWidgetInterface *createWidget(int startnow) const override;
 signals:
     void finished();

--- a/lib/qtermwidget_interface.h
+++ b/lib/qtermwidget_interface.h
@@ -99,9 +99,11 @@ class QTermWidgetInterface {
    virtual void setBoldIntense(bool boldIntense) = 0;
    virtual void setConfirmMultilinePaste(bool confirmMultilinePaste) = 0;
    virtual void setTrimPastedTrailingNewlines(bool trimPastedTrailingNewlines) = 0;
+   virtual QString wordCharacters() const = 0;
+   virtual void setWordCharacters(const QString& chars) = 0;
    virtual QTermWidgetInterface* createWidget(int startnow) const = 0;
 };
 
-#define QTermWidgetInterface_iid "lxqt.qtermwidget.QTermWidgetInterface/1.0"
+#define QTermWidgetInterface_iid "lxqt.qtermwidget.QTermWidgetInterface/1.5"
 
 Q_DECLARE_INTERFACE(QTermWidgetInterface, QTermWidgetInterface_iid)


### PR DESCRIPTION
A feature that QTerminal is missing, which is present in gnome-terminal, is the ability to configure which characters are considered "word" characters for the purposes of double-click selection. ([Feature request](https://github.com/lxqt/qterminal/issues/1098))

QTermWidget has internal support for configuring those characters, inherited from Konsole, but its public API provides no way to do so. This PR adds `wordCharacters() const` and `setWordCharacters()` to QTermWidget in order to support this feature.