### PR TITLE
Qt6 Only 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,16 +32,15 @@ set(QTERMWIDGET_VERSION "${QTERMWIDGET_VERSION_MAJOR}.${QTERMWIDGET_VERSION_MINO
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-# Minimum Versions
-set(QT_MINIMUM_VERSION "5.15.0")
-set(LXQTBT_MINIMUM_VERSION "0.13.0")
-
 if(NOT USE_QT6)
-    find_package(Qt5 "${QT_MINIMUM_VERSION}" REQUIRED COMPONENTS Widgets LinguistTools)
+    set(QTERMWIDGET_LIBRARY_NAME qtermwidget5)
+    find_package(Qt5 "5.15.0" REQUIRED COMPONENTS Widgets LinguistTools)
+    find_package(lxqt-build-tools "0.13.0" REQUIRED)
 else()
-    find_package(Qt6 "${QT_MINIMUM_VERSION}" REQUIRED COMPONENTS Widgets LinguistTools Core5Compat)
+    set(QTERMWIDGET_LIBRARY_NAME qtermwidget6)
+    find_package(Qt6 "6.3.0" REQUIRED COMPONENTS Widgets LinguistTools Core5Compat)
+    find_package(lxqt2-build-tools "2.0.0" REQUIRED)
 endif()
-find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 
 if(USE_UTF8PROC)
     find_package(Utf8Proc REQUIRED)
@@ -58,9 +57,6 @@ if(APPLE)
         set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
     endif()
 endif()
-
-set(QTERMWIDGET_LIBRARY_NAME qtermwidget5)
-
 
 # main library
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,8 @@ target_compile_definitions(${QTERMWIDGET_LIBRARY_NAME}
         "TRANSLATIONS_DIR=\"${TRANSLATIONS_DIR}\""
         "HAVE_POSIX_OPENPT"
         "HAVE_SYS_TIME_H"
+        # https://www.kdab.com/un-deprecate-qt-project/
+        "QT_DISABLE_DEPRECATED_BEFORE=0x050e00"
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(BUILD_EXAMPLE "Build example application. Default OFF." OFF)
 option(QTERMWIDGET_USE_UTEMPTER "Uses libutempter on Linux or libulog on FreeBSD for login records." OFF)
 option(QTERMWIDGET_BUILD_PYTHON_BINDING "Build python binding" OFF)
 option(USE_UTF8PROC "Use libutf8proc for better Unicode support. Default OFF" OFF)
+option(USE_QT6 "Build with Qt 6 instead of Qt 5" OFF)
 
 
 # just change version for releases
@@ -35,8 +36,11 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(QT_MINIMUM_VERSION "5.15.0")
 set(LXQTBT_MINIMUM_VERSION "0.13.0")
 
-find_package(Qt5Widgets "${QT_MINIMUM_VERSION}" REQUIRED)
-find_package(Qt5LinguistTools "${QT_MINIMUM_VERSION}" REQUIRED)
+if(NOT USE_QT6)
+    find_package(Qt5 "${QT_MINIMUM_VERSION}" REQUIRED COMPONENTS Widgets LinguistTools)
+else()
+    find_package(Qt6 "${QT_MINIMUM_VERSION}" REQUIRED COMPONENTS Widgets LinguistTools Core5Compat)
+endif()
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 
 if(USE_UTF8PROC)
@@ -130,9 +134,15 @@ set(QTERMWIDGET_INCLUDE_DIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${QTERMWIDGET_LIBR
 
 CHECK_FUNCTION_EXISTS(updwtmpx HAVE_UPDWTMPX)
 
-qt5_wrap_cpp(MOCS ${HDRS})
-qt5_wrap_ui(UI_SRCS ${UI})
-set(PKG_CONFIG_REQ "Qt5Widgets")
+if(NOT USE_QT6)
+    qt5_wrap_cpp(MOCS ${HDRS})
+    qt5_wrap_ui(UI_SRCS ${UI})
+    set(PKG_CONFIG_REQ "Qt5Widgets")
+else()
+    qt6_wrap_cpp(MOCS ${HDRS})
+    qt6_wrap_ui(UI_SRCS ${UI})
+    set(PKG_CONFIG_REQ "Qt6Widgets")
+endif()
 
 lxqt_translate_ts(QTERMWIDGET_QM
     TRANSLATION_DIR "lib/translations"
@@ -147,7 +157,11 @@ lxqt_translate_ts(QTERMWIDGET_QM
 )
 
 add_library(${QTERMWIDGET_LIBRARY_NAME} SHARED ${SRCS} ${MOCS} ${UI_SRCS} ${QTERMWIDGET_QM})
-target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt5::Widgets)
+if(NOT USE_QT6)
+    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt5::Widgets)
+else()
+    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt6::Widgets Qt6::Core5Compat)
+endif()
 set_target_properties( ${QTERMWIDGET_LIBRARY_NAME} PROPERTIES
                        SOVERSION ${QTERMWIDGET_VERSION_MAJOR}
                        VERSION ${QTERMWIDGET_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 # CMP0000: Call the cmake_minimum_required() command at the beginning of the top-level
 # CMakeLists.txt file even before calling the project() command.
 # The cmake_minimum_required(VERSION) command implicitly invokes the cmake_policy(VERSION)
@@ -17,13 +17,11 @@ option(BUILD_EXAMPLE "Build example application. Default OFF." OFF)
 option(QTERMWIDGET_USE_UTEMPTER "Uses libutempter on Linux or libulog on FreeBSD for login records." OFF)
 option(QTERMWIDGET_BUILD_PYTHON_BINDING "Build python binding" OFF)
 option(USE_UTF8PROC "Use libutf8proc for better Unicode support. Default OFF" OFF)
-option(USE_QT6 "Build with Qt 6 instead of Qt 5" OFF)
-
 
 # just change version for releases
 # keep this in sync with the version in pyqt/pyproject.toml
-set(QTERMWIDGET_VERSION_MAJOR "1")
-set(QTERMWIDGET_VERSION_MINOR "4")
+set(QTERMWIDGET_VERSION_MAJOR "2")
+set(QTERMWIDGET_VERSION_MINOR "0")
 set(QTERMWIDGET_VERSION_PATCH "0")
 
 set(QTERMWIDGET_VERSION "${QTERMWIDGET_VERSION_MAJOR}.${QTERMWIDGET_VERSION_MINOR}.${QTERMWIDGET_VERSION_PATCH}")
@@ -32,15 +30,9 @@ set(QTERMWIDGET_VERSION "${QTERMWIDGET_VERSION_MAJOR}.${QTERMWIDGET_VERSION_MINO
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-if(NOT USE_QT6)
-    set(QTERMWIDGET_LIBRARY_NAME qtermwidget5)
-    find_package(Qt5 "5.15.0" REQUIRED COMPONENTS Widgets LinguistTools)
-    find_package(lxqt-build-tools "0.13.0" REQUIRED)
-else()
-    set(QTERMWIDGET_LIBRARY_NAME qtermwidget6)
-    find_package(Qt6 "6.3.0" REQUIRED COMPONENTS Widgets LinguistTools Core5Compat)
-    find_package(lxqt2-build-tools "2.0.0" REQUIRED)
-endif()
+set(QTERMWIDGET_LIBRARY_NAME qtermwidget6)
+find_package(Qt6 "6.3.0" REQUIRED COMPONENTS Widgets LinguistTools Core5Compat)
+find_package(lxqt2-build-tools "2.0.0" REQUIRED)
 
 if(USE_UTF8PROC)
     find_package(Utf8Proc REQUIRED)
@@ -130,15 +122,9 @@ set(QTERMWIDGET_INCLUDE_DIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${QTERMWIDGET_LIBR
 
 CHECK_FUNCTION_EXISTS(updwtmpx HAVE_UPDWTMPX)
 
-if(NOT USE_QT6)
-    qt5_wrap_cpp(MOCS ${HDRS})
-    qt5_wrap_ui(UI_SRCS ${UI})
-    set(PKG_CONFIG_REQ "Qt5Widgets")
-else()
-    qt6_wrap_cpp(MOCS ${HDRS})
-    qt6_wrap_ui(UI_SRCS ${UI})
-    set(PKG_CONFIG_REQ "Qt6Widgets")
-endif()
+qt6_wrap_cpp(MOCS ${HDRS})
+qt6_wrap_ui(UI_SRCS ${UI})
+set(PKG_CONFIG_REQ "Qt6Widgets")
 
 lxqt_translate_ts(QTERMWIDGET_QM
     TRANSLATION_DIR "lib/translations"
@@ -153,11 +139,7 @@ lxqt_translate_ts(QTERMWIDGET_QM
 )
 
 add_library(${QTERMWIDGET_LIBRARY_NAME} SHARED ${SRCS} ${MOCS} ${UI_SRCS} ${QTERMWIDGET_QM})
-if(NOT USE_QT6)
-    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt5::Widgets)
-else()
-    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt6::Widgets Qt6::Core5Compat)
-endif()
+target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} Qt6::Widgets Qt6::Core5Compat)
 set_target_properties( ${QTERMWIDGET_LIBRARY_NAME} PROPERTIES
                        SOVERSION ${QTERMWIDGET_VERSION_MAJOR}
                        VERSION ${QTERMWIDGET_VERSION}

--- a/cmake/qtermwidget6-config.cmake.in
+++ b/cmake/qtermwidget6-config.cmake.in
@@ -1,10 +1,10 @@
 # - Find the QTermWidget include and library
 #
 # Typical usage:
-#    find_package(QTermWidget5 REQUIRED)
+#    find_package(QTermWidget6 REQUIRED)
 #
 #    add_executable(foo main.cpp)
-#    target_link_libraries(foo qtermwidget5)
+#    target_link_libraries(foo qtermwidget6)
 
 @PACKAGE_INIT@
 

--- a/examples/pyqt/main.py
+++ b/examples/pyqt/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from PyQt5 import QtWidgets
+from PyQt6 import QtWidgets
 from QTermWidget import QTermWidget
 
 

--- a/lib/ColorScheme.cpp
+++ b/lib/ColorScheme.cpp
@@ -364,9 +364,9 @@ void ColorScheme::readColorEntry(QSettings * s , int index)
         if (hexColorPattern.match(colorStr).hasMatch())
         {
             // Parsing is always ok as already matched by the regexp
-            r = colorStr.midRef(1, 2).toInt(nullptr, 16);
-            g = colorStr.midRef(3, 2).toInt(nullptr, 16);
-            b = colorStr.midRef(5, 2).toInt(nullptr, 16);
+            r = colorStr.mid(1, 2).toInt(nullptr, 16);
+            g = colorStr.mid(3, 2).toInt(nullptr, 16);
+            b = colorStr.mid(5, 2).toInt(nullptr, 16);
             ok = true;
         }
     }

--- a/lib/HistorySearch.cpp
+++ b/lib/HistorySearch.cpp
@@ -19,12 +19,13 @@
 #include <QApplication>
 #include <QTextStream>
 #include <QDebug>
+#include <QRegularExpressionMatch>
 
 #include "TerminalCharacterDecoder.h"
 #include "Emulation.h"
 #include "HistorySearch.h"
 
-HistorySearch::HistorySearch(EmulationPtr emulation, const QRegExp& regExp,
+HistorySearch::HistorySearch(EmulationPtr emulation, const QRegularExpression& regExp,
         bool forwards, int startColumn, int startLine,
         QObject* parent) :
 QObject(parent),
@@ -41,7 +42,7 @@ HistorySearch::~HistorySearch() {
 void HistorySearch::search() {
     bool found = false;
 
-    if (! m_regExp.isEmpty())
+    if (! m_regExp.pattern().isEmpty())
     {
         if (m_forwards) {
             found = search(m_startColumn, m_startLine, -1, m_emulation->lineCount()) || search(0, 0, m_startColumn, m_startLine);
@@ -104,22 +105,23 @@ bool HistorySearch::search(int startColumn, int startLine, int endColumn, int en
 
         // So now we can log for m_regExp in the string between startColumn and endPosition
         int matchStart;
+        QRegularExpressionMatch match;
         if (m_forwards)
         {
-            matchStart = string.indexOf(m_regExp, startColumn);
+            matchStart = string.indexOf(m_regExp, startColumn, &match);
             if (matchStart >= endPosition)
                 matchStart = -1;
         }
         else
         {
-            matchStart = string.lastIndexOf(m_regExp, endPosition - 1);
+            matchStart = string.lastIndexOf(m_regExp, endPosition - 1, &match);
             if (matchStart < startColumn)
                 matchStart = -1;
         }
 
         if (matchStart > -1)
         {
-            int matchEnd = matchStart + m_regExp.matchedLength() - 1;
+            int matchEnd = matchStart + match.capturedLength() - 1;
             qDebug() << "Found in string from" << matchStart << "to" << matchEnd;
 
             // Translate startPos and endPos to startColum, startLine, endColumn and endLine in history.

--- a/lib/HistorySearch.h
+++ b/lib/HistorySearch.h
@@ -22,6 +22,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QMap>
+#include <QRegularExpression>
 
 #include <Session.h>
 #include <ScreenWindow.h>
@@ -38,7 +39,7 @@ class HistorySearch : public QObject
     Q_OBJECT
 
 public:
-    explicit HistorySearch(EmulationPtr emulation, const QRegExp& regExp, bool forwards,
+    explicit HistorySearch(EmulationPtr emulation, const QRegularExpression& regExp, bool forwards,
                            int startColumn, int startLine, QObject* parent);
 
     ~HistorySearch() override;
@@ -55,7 +56,7 @@ private:
 
 
     EmulationPtr m_emulation;
-    QRegExp m_regExp;
+    QRegularExpression m_regExp;
     bool m_forwards = false;
     int m_startColumn = 0;
     int m_startLine = 0;

--- a/lib/KeyboardTranslator.cpp
+++ b/lib/KeyboardTranslator.cpp
@@ -679,7 +679,7 @@ QByteArray KeyboardTranslator::Entry::escapedText(bool expandWildCards,Qt::Keybo
         {
             QByteArray escaped("\\x");
             escaped += QByteArray(1,ch).toHex();
-            result.replace(i, 1, QByteArrayView(escaped));
+            result.replace(i, 1, escaped);
         } else if ( replacement != 0 )
         {
             result.remove(i,1);

--- a/lib/KeyboardTranslator.cpp
+++ b/lib/KeyboardTranslator.cpp
@@ -34,6 +34,7 @@
 #include <QKeySequence>
 #include <QDir>
 #include <QtDebug>
+#include <QRegExp>
 
 #include "tools.h"
 
@@ -676,7 +677,9 @@ QByteArray KeyboardTranslator::Entry::escapedText(bool expandWildCards,Qt::Keybo
 
         if ( replacement == 'x' )
         {
-            result.replace(i,1,"\\x"+QByteArray(1,ch).toHex());
+            QByteArray escaped("\\x");
+            escaped += QByteArray(1,ch).toHex();
+            result.replace(i, 1, QByteArrayView(escaped));
         } else if ( replacement != 0 )
         {
             result.remove(i,1);
@@ -694,7 +697,7 @@ QByteArray KeyboardTranslator::Entry::unescape(const QByteArray& input) const
     for ( int i = 0 ; i < result.count()-1 ; i++ )
     {
 
-        QByteRef ch = result[i];
+        char ch = result[i];
         if ( ch == '\\' )
         {
            char replacement[2] = {0,0};

--- a/lib/Pty.cpp
+++ b/lib/Pty.cpp
@@ -326,9 +326,9 @@ int Pty::foregroundProcessGroup() const
     return 0;
 }
 
-void Pty::setupChildProcess()
+void Pty::setupChildProcess_()
 {
-    KPtyProcess::setupChildProcess();
+    KPtyProcess::setupChildProcess_();
 
     // reset all signal handlers
     // this ensures that terminal applications respond to

--- a/lib/Pty.cpp
+++ b/lib/Pty.cpp
@@ -271,6 +271,26 @@ Pty::Pty(QObject* parent)
 }
 void Pty::init()
 {
+   // Must call parent class child process modifier, as it sets file descriptors ...etc
+   auto parentChildProcModifier = KPtyProcess::childProcessModifier();
+   setChildProcessModifier([parentChildProcModifier = std::move(parentChildProcModifier)]() {
+       if (parentChildProcModifier) {
+           parentChildProcModifier();
+       }
+
+       // reset all signal handlers
+       // this ensures that terminal applications respond to
+       // signals generated via key sequences such as Ctrl+C
+       // (which sends SIGINT)
+       struct sigaction action;
+       sigemptyset(&action.sa_mask);
+       action.sa_handler = SIG_DFL;
+       action.sa_flags = 0;
+       for (int signal = 1; signal < NSIG; signal++) {
+           sigaction(signal, &action, nullptr);
+       }
+   });
+
   _windowColumns = 0;
   _windowLines = 0;
   _eraseChar = 0;
@@ -326,23 +346,3 @@ int Pty::foregroundProcessGroup() const
     return 0;
 }
 
-void Pty::setupChildProcess_()
-{
-    KPtyProcess::setupChildProcess_();
-
-    // reset all signal handlers
-    // this ensures that terminal applications respond to
-    // signals generated via key sequences such as Ctrl+C
-    // (which sends SIGINT)
-    struct sigaction action;
-    sigset_t sigset;
-    sigemptyset(&action.sa_mask);
-    sigemptyset(&sigset);
-    action.sa_handler = SIG_DFL;
-    action.sa_flags = 0;
-    for (int signal=1;signal < NSIG; signal++) {
-        sigaction(signal,&action,nullptr);
-        sigaddset(&sigset, signal);
-    }
-    sigprocmask(SIG_UNBLOCK, &sigset, nullptr);
-}

--- a/lib/Pty.h
+++ b/lib/Pty.h
@@ -189,7 +189,6 @@ Q_OBJECT
     void receivedData(const char* buffer, int length);
 
   protected:
-      void setupChildProcess_() override;
 
   private slots:
     // called when data is received from the terminal process

--- a/lib/Pty.h
+++ b/lib/Pty.h
@@ -189,7 +189,7 @@ Q_OBJECT
     void receivedData(const char* buffer, int length);
 
   protected:
-      void setupChildProcess() override;
+      void setupChildProcess_() override;
 
   private slots:
     // called when data is received from the terminal process

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -30,7 +30,6 @@
 
 // Qt
 #include <QApplication>
-#include <QByteRef>
 #include <QDir>
 #include <QFile>
 #include <QRegExp>

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -32,7 +32,7 @@
 #include <QApplication>
 #include <QDir>
 #include <QFile>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QStringList>
 #include <QFile>
 #include <QtDebug>
@@ -380,7 +380,7 @@ void Session::setUserTitle( int what, const QString & caption )
 
     if (what == 31) {
         QString cwd=caption;
-        cwd=cwd.replace( QRegExp(QLatin1String("^~")), QDir::homePath() );
+        cwd=cwd.replace( QRegularExpression(QLatin1String("^~")), QDir::homePath() );
         emit openUrlRequest(cwd);
     }
 

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -275,14 +275,8 @@ void TerminalDisplay::setVTFont(const QFont& f)
 {
   QFont font = f;
 
-  // This was originally set for OS X only:
-  //     mac uses floats for font width specification.
-  //     this ensures the same handling for all platforms
-  // but then there was revealed that various Linux distros
-  // have this problem too...
-  font.setStyleStrategy(QFont::ForceIntegerMetrics);
-
-  if ( !QFontInfo(font).fixedPitch() )
+  // Check if font is not fixed pitch and print a warning
+  if (!QFontInfo(font).fixedPitch())
   {
       qDebug() << "Using a variable-width font in the terminal.  This may cause performance degradation and display/alignment errors.";
   }
@@ -293,7 +287,7 @@ void TerminalDisplay::setVTFont(const QFont& f)
       font.setStyleStrategy( QFont::NoAntialias );
 
   // experimental optimization.  Konsole assumes that the terminal is using a
-  // mono-spaced font, in which case kerning information should have an effect.
+  // mono-spaced font, in which case kerning information should have no effect.
   // Disabling kerning saves some computation when rendering text.
   font.setKerning(false);
 
@@ -1619,7 +1613,7 @@ int TerminalDisplay::textWidth(const int startColumn, const int length, const in
   QFontMetrics fm(font());
   int result = 0;
   for (int column = 0; column < length; column++) {
-    result += fm.horizontalAdvance(_image[loc(startColumn + column, line)].character);
+    result += fm.horizontalAdvance(QChar(static_cast<ushort>(_image[loc(startColumn + column, line)].character)));
   }
   return result;
 }
@@ -2221,9 +2215,9 @@ void TerminalDisplay::extendSelection( const QPoint& position )
     QPoint left = left_not_right ? here : _iPntSelCorr;
     i = loc(left.x(),left.y());
     if (i>=0 && i<=_imageSize) {
-      selClass = charClass(_image[i].character);
+      selClass = charClass(QChar(static_cast<ushort>(_image[i].character)));
       while ( ((left.x()>0) || (left.y()>0 && (_lineProperties[left.y()-1] & LINE_WRAPPED) ))
-                      && charClass(_image[i-1].character) == selClass )
+                      && charClass(QChar(static_cast<ushort>(_image[i-1].character))) == selClass )
       { i--; if (left.x()>0) left.rx()--; else {left.rx()=_usedColumns-1; left.ry()--;} }
     }
 
@@ -2231,9 +2225,9 @@ void TerminalDisplay::extendSelection( const QPoint& position )
     QPoint right = left_not_right ? _iPntSelCorr : here;
     i = loc(right.x(),right.y());
     if (i>=0 && i<=_imageSize) {
-      selClass = charClass(_image[i].character);
+      selClass = charClass(QChar(static_cast<ushort>(_image[i].character)));
       while( ((right.x()<_usedColumns-1) || (right.y()<_usedLines-1 && (_lineProperties[right.y()] & LINE_WRAPPED) ))
-                      && charClass(_image[i+1].character) == selClass )
+                      && charClass(QChar(static_cast<ushort>(_image[i+1].character))) == selClass )
       { i++; if (right.x()<_usedColumns-1) right.rx()++; else {right.rx()=0; right.ry()++; } }
     }
 
@@ -2303,7 +2297,7 @@ void TerminalDisplay::extendSelection( const QPoint& position )
     {
       i = loc(right.x(),right.y());
       if (i>=0 && i<=_imageSize) {
-        selClass = charClass(_image[i-1].character);
+        selClass = charClass(QChar(static_cast<ushort>(_image[i-1].character)));
        /* if (selClass == ' ')
         {
           while ( right.x() < _usedColumns-1 && charClass(_image[i+1].character) == selClass && (right.y()<_usedLines-1) &&
@@ -2491,12 +2485,12 @@ void TerminalDisplay::mouseDoubleClickEvent(QMouseEvent* ev)
   _wordSelectionMode = true;
 
   // find word boundaries...
-  QChar selClass = charClass(_image[i].character);
+  QChar selClass = charClass(QChar(static_cast<ushort>(_image[i].character)));
   {
      // find the start of the word
      int x = bgnSel.x();
      while ( ((x>0) || (bgnSel.y()>0 && (_lineProperties[bgnSel.y()-1] & LINE_WRAPPED) ))
-                     && charClass(_image[i-1].character) == selClass )
+                     && charClass(QChar(static_cast<ushort>(_image[i-1].character))) == selClass )
      {
        i--;
        if (x>0)
@@ -2515,7 +2509,7 @@ void TerminalDisplay::mouseDoubleClickEvent(QMouseEvent* ev)
      i = loc( endSel.x(), endSel.y() );
      x = endSel.x();
      while( ((x<_usedColumns-1) || (endSel.y()<_usedLines-1 && (_lineProperties[endSel.y()] & LINE_WRAPPED) ))
-                     && charClass(_image[i+1].character) == selClass )
+                     && charClass(QChar(static_cast<ushort>(_image[i+1].character))) == selClass )
      {
          i++;
          if (x<_usedColumns-1)
@@ -2624,13 +2618,13 @@ void TerminalDisplay::mouseTripleClickEvent(QMouseEvent* ev)
   if (_tripleClickMode == SelectForwardsFromCursor) {
     // find word boundary start
     int i = loc(_iPntSel.x(),_iPntSel.y());
-    QChar selClass = charClass(_image[i].character);
+    QChar selClass = charClass(QChar(static_cast<ushort>(_image[i].character)));
     int x = _iPntSel.x();
 
     while ( ((x>0) ||
              (_iPntSel.y()>0 && (_lineProperties[_iPntSel.y()-1] & LINE_WRAPPED) )
             )
-            && charClass(_image[i-1].character) == selClass )
+            && charClass(QChar(static_cast<ushort>(_image[i-1].character))) == selClass )
     {
         i--;
         if (x>0)

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -23,6 +23,7 @@
 // Own
 #include "Vt102Emulation.h"
 #include "tools.h"
+#include <string>
 
 // Standard
 #include <cstdio>
@@ -953,8 +954,8 @@ void Vt102Emulation::sendMouseEvent( int cb, int cx, int cy , int eventType )
             // coordinate+32, no matter what the locale is. We could easily
             // convert manually, but QString can also do it for us.
             QChar coords[2];
-            coords[0] = cx + 0x20;
-            coords[1] = cy + 0x20;
+            coords[0] = static_cast<char16_t>(cx + 0x20);
+            coords[1] = static_cast<char16_t>(cy + 0x20);
             QString coordsStr = QString(coords, 2);
             QByteArray utf8 = coordsStr.toUtf8();
             snprintf(command, sizeof(command), "\033[M%c%s", cb + 0x20, utf8.constData());

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -31,7 +31,6 @@
 // Qt
 #include <QEvent>
 #include <QKeyEvent>
-#include <QByteRef>
 #include <QDebug>
 
 // Konsole

--- a/lib/kprocess.h
+++ b/lib/kprocess.h
@@ -327,8 +327,6 @@ protected:
 
 private:
     // hide those
-    using QProcess::setReadChannelMode;
-    using QProcess::readChannelMode;
     using QProcess::setProcessChannelMode;
     using QProcess::processChannelMode;
 };

--- a/lib/kptyprocess.cpp
+++ b/lib/kptyprocess.cpp
@@ -48,6 +48,24 @@ KPtyProcess::KPtyProcess(int ptyMasterFd, QObject *parent) :
 {
     Q_D(KPtyProcess);
 
+    setChildProcessModifier([d]() {
+        d->pty->setCTty();
+#if 0
+        if (d->addUtmp) {
+            d->pty->login(KUser(KUser::UseRealUserID).loginName().toLocal8Bit().constData(), qgetenv("DISPLAY").constData());
+        }
+#endif
+        if (d->ptyChannels & StdinChannel) {
+            dup2(d->pty->slaveFd(), 0);
+        }
+        if (d->ptyChannels & StdoutChannel) {
+            dup2(d->pty->slaveFd(), 1);
+        }
+        if (d->ptyChannels & StderrChannel) {
+            dup2(d->pty->slaveFd(), 2);
+        }
+    });
+
     d->pty = std::make_unique<KPtyDevice>(this);
 
     if (ptyMasterFd == -1) {
@@ -119,29 +137,6 @@ KPtyDevice *KPtyProcess::pty() const
     Q_D(const KPtyProcess);
 
     return d->pty.get();
-}
-
-void KPtyProcess::setupChildProcess_()
-{
-    Q_D(KPtyProcess);
-
-    d->pty->setCTty();
-
-#if 0
-    if (d->addUtmp)
-        d->pty->login(KUser(KUser::UseRealUserID).loginName().toLocal8Bit().data(), qgetenv("DISPLAY"));
-#endif
-    if (d->ptyChannels & StdinChannel)
-        dup2(d->pty->slaveFd(), 0);
-
-    if (d->ptyChannels & StdoutChannel)
-        dup2(d->pty->slaveFd(), 1);
-
-    if (d->ptyChannels & StderrChannel)
-        dup2(d->pty->slaveFd(), 2);
-
-    // https://phabricator.kde.org/T13940
-    // KProcess::setupChildProcess();
 }
 
 //#include "kptyprocess.moc"

--- a/lib/kptyprocess.cpp
+++ b/lib/kptyprocess.cpp
@@ -121,7 +121,7 @@ KPtyDevice *KPtyProcess::pty() const
     return d->pty.get();
 }
 
-void KPtyProcess::setupChildProcess()
+void KPtyProcess::setupChildProcess_()
 {
     Q_D(KPtyProcess);
 
@@ -140,7 +140,8 @@ void KPtyProcess::setupChildProcess()
     if (d->ptyChannels & StderrChannel)
         dup2(d->pty->slaveFd(), 2);
 
-    KProcess::setupChildProcess();
+    // https://phabricator.kde.org/T13940
+    // KProcess::setupChildProcess();
 }
 
 //#include "kptyprocess.moc"

--- a/lib/kptyprocess.h
+++ b/lib/kptyprocess.h
@@ -145,7 +145,7 @@ protected:
     /**
      * @reimp
      */
-    void setupChildProcess() override;
+    virtual void setupChildProcess_();
 
 private:
     std::unique_ptr<KPtyProcessPrivate> const d_ptr;

--- a/lib/kptyprocess.h
+++ b/lib/kptyprocess.h
@@ -142,10 +142,6 @@ public:
     KPtyDevice *pty() const;
 
 protected:
-    /**
-     * @reimp
-     */
-    virtual void setupChildProcess_();
 
 private:
     std::unique_ptr<KPtyProcessPrivate> const d_ptr;

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -271,7 +271,7 @@ void QTermWidget::startTerminalTeletype()
 void QTermWidget::init(int startnow)
 {
     m_layout = new QVBoxLayout();
-    m_layout->setMargin(0);
+    m_layout->setContentsMargins(0, 0, 0, 0);
     setLayout(m_layout);
 
     // translations

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -21,6 +21,7 @@
 #include <QtDebug>
 #include <QDir>
 #include <QMessageBox>
+#include <QRegularExpression>
 
 #include "ColorTables.h"
 #include "Session.h"
@@ -167,9 +168,13 @@ void QTermWidget::search(bool forwards, bool next)
     //qDebug() << "current selection starts at: " << startColumn << startLine;
     //qDebug() << "current cursor position: " << m_impl->m_terminalDisplay->screenWindow()->cursorPosition();
 
-    QRegExp regExp(m_searchBar->searchText());
-    regExp.setPatternSyntax(m_searchBar->useRegularExpression() ? QRegExp::RegExp : QRegExp::FixedString);
-    regExp.setCaseSensitivity(m_searchBar->matchCase() ? Qt::CaseSensitive : Qt::CaseInsensitive);
+    QRegularExpression regExp;
+    if (m_searchBar->useRegularExpression()) {
+        regExp.setPattern(m_searchBar->searchText());
+    } else {
+        regExp.setPattern(QRegularExpression::escape(m_searchBar->searchText()));
+    }
+    regExp.setPatternOptions(m_searchBar->matchCase() ? QRegularExpression::NoPatternOption : QRegularExpression::CaseInsensitiveOption);
 
     HistorySearch *historySearch =
             new HistorySearch(m_impl->m_session->emulation(), regExp, forwards, startColumn, startLine, this);

--- a/pyqt/project.py
+++ b/pyqt/project.py
@@ -11,5 +11,5 @@ class QTermWidgetBindings(PyQtBindings):
         self._project = project
 
     def apply_user_defaults(self, tool):
-        self.libraries.append('qtermwidget5')
+        self.libraries.append('qtermwidget6')
         super().apply_user_defaults(tool)

--- a/pyqt/pyproject.toml
+++ b/pyqt/pyproject.toml
@@ -6,5 +6,5 @@ build-backend = "sipbuild.api"
 
 [tool.sip.metadata]
 name = "QTermWidget"
-version = "1.4.0"
-requires-dist = ["PyQt5"]
+version = "2.0.0"
+requires-dist = ["PyQt6"]


### PR DESCRIPTION
 * Rebased the [wip-qt6 branch](https://github.com/lxqt/qtermwidget/tree/wip-qt6)
 * Purged all the Qt5 stuff from the buildsystem
 * Ported `QProcess::setupChildProcess()` to `QProcess::setChildProcessModifier()`
 
When used with [QTerminal wip-qt6](https://github.com/lxqt/qterminal/tree/wip-qt6) branch it results in a working QTerminal app.

p.s. Only when writing this I realized about #532. Didn't check it's status, yet. 

![qterminal2](https://github.com/lxqt/qtermwidget/assets/62877/01d633fd-43fa-4ad2-9d01-98e57b7dc7f8)
