### PR TITLE
Adapt to Qt6 QProcess::setChildProcessModifier()

### DIFF
--- a/lib/Pty.h
+++ b/lib/Pty.h
@@ -188,9 +188,6 @@ Q_OBJECT
      */
     void receivedData(const char* buffer, int length);
 
-  protected:
-      void onSetupChildProcess() override;
-
   private slots:
     // called when data is received from the terminal process
     void dataReceived();

--- a/lib/kptyprocess.h
+++ b/lib/kptyprocess.h
@@ -142,10 +142,6 @@ public:
     KPtyDevice *pty() const;
 
 protected:
-    /**
-     * Child process configuration
-     */
-    virtual void onSetupChildProcess();
 
 private:
     std::unique_ptr<KPtyProcessPrivate> const d_ptr;


### PR DESCRIPTION
Qt5 QProcess::setupChildProcess() was removed.
Based on KDE KPty commit 2117727305e8d69998154c667c284ded6b390652.

It keeps sync with upstream code.

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

