### PR TITLE
Fixed comparison of pointer addition with NULL

### DIFF
--- a/lib/TerminalCharacterDecoder.cpp
+++ b/lib/TerminalCharacterDecoder.cpp
@@ -79,14 +79,11 @@ void PlainTextDecoder::decodeLine(const Character* const characters, int count, 
         _linePositions << pos;
     }
 
-    // check the real length
-    for (int i = 0 ; i < count ; i++)
+    if (characters == nullptr)
     {
-        if (characters + i == nullptr)
-        {
-            count = i;
-            break;
-        }
+        // TODO: So far, this has happened only under kwin_wayland, when the current function
+        // is called by TerminalDisplay::inputMethodQuery(). The actual issue should be found.
+        return;
     }
 
     //TODO should we ignore or respect the LINE_WRAPPED line property?


### PR DESCRIPTION
The comparison was added to fix a crash under Plasma-Wayland, when the terminal was split horizontally. Instead, a simple nullity check was enough.

The following compilation warning is also silenced:

```
qtermwidget/lib/TerminalCharacterDecoder.cpp:85:28: warning: comparing the result of pointer addition ‘(((const Konsole::Character*)characters) + ((sizetype)(((long unsigned int)i) * 16)))’ and NULL [-Waddress]
   85 |         if (characters + i == nullptr)
```

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

