### PR TITLE
Silenced old compilation warnings

### DIFF
--- a/lib/BlockArray.cpp
+++ b/lib/BlockArray.cpp
@@ -230,7 +230,8 @@ bool BlockArray::setHistorySize(size_t newsize)
         return false;
     } else {
         decreaseBuffer(newsize);
-        ftruncate(ion, length*blocksize);
+        int res = ftruncate(ion, length*blocksize);
+        Q_UNUSED (res);
         size = newsize;
 
         return true;

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -940,7 +940,7 @@ void Vt102Emulation::sendMouseEvent( int cb, int cx, int cy , int eventType )
     if ((getMode(MODE_Mouse1002) || getMode(MODE_Mouse1003)) && eventType == 1)
       cb += 0x20; //add 32 to signify motion event
 
-    char command[32];
+    char command[40];
     command[0] = '\0';
     // Check the extensions in decreasing order of preference. Encoding the release event above assumes that 1006 comes first.
     if (getMode(MODE_Mouse1006)) {

--- a/lib/kpty.cpp
+++ b/lib/kpty.cpp
@@ -467,7 +467,8 @@ void KPty::close()
         if (!geteuid()) {
             struct stat st;
             if (!stat(d->ttyName.data(), &st)) {
-                chown(d->ttyName.data(), 0, st.st_gid == getgid() ? 0 : -1);
+                int res = chown(d->ttyName.data(), 0, st.st_gid == getgid() ? 0 : -1);
+                Q_UNUSED (res);
                 chmod(d->ttyName.data(), S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
             }
         } else {


### PR DESCRIPTION
Consulted Konsole's code fo `char command[40];`. Previously, this warning was shown:

```
…/qtermwidget/lib/Vt102Emulation.cpp: In member function ‘virtual void Konsole::Vt102Emulation::sendMouseEvent(int, int, int, int)’:
…/qtermwidget/lib/Vt102Emulation.cpp:949:56: warning: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size between 7 and 26 [-Wformat-truncation=]
  949 |         snprintf(command, sizeof(command), "\033[%d;%d;%dM", cb + 0x20, cx, cy);
      |                                                        ^~
…/qtermwidget/lib/Vt102Emulation.cpp:949:44: note: directive argument in the range [1, 2147483647]
  949 |         snprintf(command, sizeof(command), "\033[%d;%d;%dM", cb + 0x20, cx, cy);
      |                                            ^~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:970,
                 from /usr/include/c++/14.2.1/cstdio:42,
                 from …/qtermwidget/lib/Vt102Emulation.h:27,
                 from …/qtermwidget/lib/Vt102Emulation.cpp:24:
In function ‘int snprintf(char*, size_t, const char*, ...)’,
    inlined from ‘virtual void Konsole::Vt102Emulation::sendMouseEvent(int, int, int, int)’ at …/qtermwidget/lib/Vt102Emulation.cpp:949:17:
/usr/include/bits/stdio2.h:68:35: note: ‘__builtin___snprintf_chk’ output between 9 and 37 bytes into a destination of size 32
   68 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   69 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   70 |                                    __va_arg_pack ());
```

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

