### PR TITLE
Close the session correctly before destroying it

### DIFF
--- a/lib/Pty.cpp
+++ b/lib/Pty.cpp
@@ -319,7 +319,11 @@ void Pty::sendData(const char* data, int length)
 
 void Pty::dataReceived()
 {
-     QByteArray data = pty()->readAll();
+    QByteArray data = pty()->readAll();
+    if (data.isEmpty())
+    {
+        return;
+    }
     emit receivedData(data.constData(),data.size());
 }
 
@@ -336,13 +340,22 @@ void Pty::lockPty(bool lock)
 
 int Pty::foregroundProcessGroup() const
 {
-    int pid = tcgetpgrp(pty()->masterFd());
-
-    if ( pid != -1 )
+    const int master_fd = pty()->masterFd();
+    if (master_fd >= 0)
     {
-        return pid;
+        int pid = tcgetpgrp(master_fd);
+
+        if (pid != -1)
+        {
+            return pid;
+        }
     }
 
     return 0;
+}
+
+void Pty::closePty()
+{
+    pty()->close();
 }
 

--- a/lib/Pty.h
+++ b/lib/Pty.h
@@ -150,6 +150,11 @@ Q_OBJECT
      */
     int foregroundProcessGroup() const;
 
+    /**
+     * Close the underlying pty master/slave pair.
+     */
+    void closePty();
+
   public slots:
 
     /**

--- a/lib/kptyprocess.cpp
+++ b/lib/kptyprocess.cpp
@@ -85,22 +85,10 @@ KPtyProcess::~KPtyProcess()
 {
     Q_D(KPtyProcess);
 
-    if (state() != QProcess::NotRunning)
+    if (state() != QProcess::NotRunning && d->addUtmp)
     {
-        if (d->addUtmp)
-        {
-            d->pty->logout();
-            disconnect(this, &QProcess::stateChanged, this, nullptr);
-        }
-    }
-    waitForFinished(300); // give it some time to finish
-    if (state() != QProcess::NotRunning)
-    {
-        qWarning() << Q_FUNC_INFO << "the terminal process is still running, trying to stop it by SIGHUP";
-        ::kill(static_cast<pid_t>(processId()), SIGHUP);
-        waitForFinished(300);
-        if (state() != QProcess::NotRunning)
-            qCritical() << Q_FUNC_INFO << "process didn't stop upon SIGHUP and will be SIGKILL-ed";
+        d->pty->logout();
+        disconnect(this, &QProcess::stateChanged, this, nullptr);
     }
 }
 


### PR DESCRIPTION
Instead of trying to stop the process in the d-tor of `KPtyProcess`, the patch does it in the d-tor of `Session`.

I consulted Konsole's code — that didn't have our problem but was very different from our code — and adapted it to ours.

Closes https://github.com/lxqt/qtermwidget/issues/566
