### PR TITLE
Handle double-column and small characters on calculating text width

### DIFF
--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -733,6 +733,7 @@ private:
     QGridLayout* _gridLayout;
 
     bool _fixedFont; // has fixed pitch
+    bool _fixedFont_original; // used only in textWidth()
     int  _fontHeight;     // height
     int  _fontWidth;     // width
     int  _fontAscent;     // ascend


### PR DESCRIPTION
Fixes https://github.com/lxqt/qterminal/issues/344

NOTE: The credit goes to @yan12125 for https://github.com/lxqt/qtermwidget/commit/1e509dbc669e22bfdf7255208c61c07ac5c461f7. I only fixed its problem.

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

