### PR TITLE
Make too wide characters fit into available space

### DIFF
--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -657,7 +657,7 @@ private:
     // draws a section of text, all the text in this section
     // has a common color and style
     void drawTextFragment(QPainter& painter, const QRect& rect,
-                          const std::wstring& text, const Character* style);
+                          const std::wstring& text, const Character* style, bool tooWide);
     // draws the background for a text fragment
     // if useOpacitySetting is true then the color's alpha value will be set to
     // the display's transparency (set with setOpacity()), otherwise the background
@@ -669,7 +669,8 @@ private:
                                        const QColor& backgroundColor , bool& invertColors);
     // draws the characters or line graphics in a text fragment
     void drawCharacters(QPainter& painter, const QRect& rect,  const std::wstring& text,
-                                           const Character* style, bool invertCharacterColor);
+                                           const Character* style, bool invertCharacterColor,
+                                           bool tooWide = false);
     // draws a string of line graphics
     void drawLineCharString(QPainter& painter, int x, int y,
                             const std::wstring& str, const Character* attributes) const;


### PR DESCRIPTION
The drawing is done like that of XTerm (actually, Qt does it), i.e., the character is "squeezed". A too wide character is defined by the code as a character whose width is twice the monospace width or more. An example is "three-em dash", which is `⸻`.

Fixes https://github.com/lxqt/qterminal/issues/685

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

