### PR TITLE
unclutter ie. hide inactive mouse cursor

### DIFF
--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -725,6 +725,8 @@ private:
     bool isLineChar(Character c) const;
     bool isLineCharString(const std::wstring& string) const;
 
+    void unclutter() const; // conditionally hides the mouse cursor
+
     // the window onto the terminal screen which this display
     // is currently showing.
     QPointer<ScreenWindow> _screenWindow;


### PR DESCRIPTION
Opted for QTimer since TerminalDisplay currently doesn't implement timerEvent() and I wanted the patch to be narrow (initilally even more, see below) - but I don't mind adding it if that's preferred.

Fwwi this *can* be done the exact same way from qterminal (or a dedicated handler) using an eventFilter - likely what KDE does/did.

Just ftr: As of Qt 6.8.1 the following approach doesn't work - the context aware connection doesn't work as advertised (no auto-disconnect, lambda fires and kills us) and actually returns the same QMetaObject::Connection.
Explicitly disconnecting it in the d'tor turns it false in the remaining instances and the (undesired anyway) reconnection attempt results in a segfault.
```diff
diff --git a/lib/TerminalDisplay.cpp b/lib/TerminalDisplay.cpp
index 6f99939..68fc52b 100644
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -437,6 +437,7 @@ TerminalDisplay::~TerminalDisplay()
 {
   disconnect(_blinkTimer);
   disconnect(_blinkCursorTimer);
+  disconnect(_mouseHiderConnection);
   qApp->removeEventFilter( this );
 
   delete[] _image;
@@ -2125,6 +2126,29 @@ QList<QAction*> TerminalDisplay::filterActions(const QPoint& position)
 
 void TerminalDisplay::mouseMoveEvent(QMouseEvent* ev)
 {
+  static QPoint deadSpot(-1,-1);
+  static QPoint futureDeadSpot;
+  static QTimer *hideMouseTimer = nullptr;
+  if (deadSpot.x() > -1 && (ev->pos() - deadSpot).manhattanLength() > 8) {
+    deadSpot = QPoint(-1,-1);
+    QApplication::restoreOverrideCursor();
+  }
+  futureDeadSpot = ev->pos();
+  if (!hideMouseTimer) {
+    hideMouseTimer = new QTimer(this);
+    hideMouseTimer->setSingleShot(true);
+    hideMouseTimer->setInterval(1000);
+  }
+  if (!_mouseHiderConnection) {
+    _mouseHiderConnection = connect(hideMouseTimer, &QTimer::timeout, this, [=]() {
+      if (underMouse() && deadSpot.x() < 0) {
+        deadSpot = futureDeadSpot;
+        QApplication::setOverrideCursor(Qt::BlankCursor);
+      }
+    });
+  }
+  hideMouseTimer->start();
+
   int charLine = 0;
   int charColumn = 0;
   int leftMargin = _leftBaseMargin
diff --git a/lib/TerminalDisplay.h b/lib/TerminalDisplay.h
index bcf0b63..0f0bafd 100644
--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -862,6 +862,8 @@ private:
 
     bool _drawLineChars;
 
+    QMetaObject::Connection _mouseHiderConnection;
+
 public:
     static void setTransparencyEnabled(bool enable)
     {
```