### PR TITLE
unclutter ie. hide inactive mouse cursor

### DIFF
--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -433,6 +433,8 @@ public:
     void disableBracketedPasteMode(bool disable) { _disabledBracketedPasteMode = disable; }
     bool bracketedPasteModeIsDisabled() const { return _disabledBracketedPasteMode; }
 
+    int mouseAutohideDelay() const { return _mouseAutohideDelay; }
+
 public slots:
 
     /**
@@ -525,6 +527,12 @@ public slots:
      * @see setColorTable(), setBackgroundColor()
      */
     void setForegroundColor(const QColor& color);
+
+    /**
+    * hide the mouse cursor after @param delay milliseconds of inactivity
+    * @param delay < 0 deactivates the behavior
+    */
+    void autoHideMouseAfter(int delay);
 
     void selectionChanged();
 
@@ -725,6 +733,8 @@ private:
     bool isLineChar(Character c) const;
     bool isLineCharString(const std::wstring& string) const;
 
+    void hideStaleMouse() const; // conditionally hides the mouse cursor
+
     // the window onto the terminal screen which this display
     // is currently showing.
     QPointer<ScreenWindow> _screenWindow;
@@ -800,6 +810,7 @@ private:
     bool _isFixedSize; //Columns / lines are locked.
     QTimer* _blinkTimer;  // active when hasBlinker
     QTimer* _blinkCursorTimer;  // active when hasBlinkingCursor
+    static std::shared_ptr<QTimer> _hideMouseTimer;
 
     //QMenu* _drop;
     QString _dropText;
@@ -861,6 +872,8 @@ private:
     int _topBaseMargin;
 
     bool _drawLineChars;
+
+    int _mouseAutohideDelay;
 
 public:
     static void setTransparencyEnabled(bool enable)


### PR DESCRIPTION
Added feature to set a random autohide delay - for demonstration uncondituinally called in the constructor until this can be merged and then used by qtermwidget.

Turns out experienced developers have a lot of experienced muscle-memory that lead to "new QSomething(this)" - which is not useful for global objects ;)
Doesn't matter, the lambda approach has little benefits (and might still race) when this needs to be dynamically activated/deactivated.

I'm not gonna complain, but the code style isn't exactly consistent in that file (starting w/ 2/4 char indents :stuck_out_tongue:  )

The other things:
while we're using global statics to track the state, each qtermwidget needs its own connection to the timer (one might go w/ qobject_cast<TerminalDisplay*>::widgetAt(QCursor::pos()) but would require an external handler for this at which point I'd imitate what KDE likely is doing and have a global manager install eventfilters and track them in a QHash/QMap)

As for "unclutter", I guess for an internal slot the reference to the unclutter tool is ok - for a public API I'd not use that indeed.
If you don't like it "::maybeHideCursor" ?

I also noticed that we still need to handle the focus (eg. for popups) because you might rest the mouse, rmb very carefully and this way spawn a popup w/o cursor.

The current implementation should work, so comment on style and approach and I'm gonna try the lambda approach again for my own sanity :wink: 