### PR TITLE
Added mouse cursor auto-hiding to `QTermWidget`

### DIFF
--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -24,7 +24,7 @@
 // Qt
 #include <QColor>
 #include <QPointer>
-#include <QWidget>
+#include <QScrollBar>
 
 // Konsole
 #include "Filter.h"
@@ -41,7 +41,6 @@ class QTimer;
 class QEvent;
 class QGridLayout;
 class QKeyEvent;
-class QScrollBar;
 class QShowEvent;
 class QHideEvent;
 class QTimerEvent;
@@ -73,6 +72,7 @@ namespace Konsole
 extern unsigned short vt100_graphics[32];
 
 class ScreenWindow;
+class ScrollBar;
 
 /**
  * A widget which displays output from a terminal emulation and sends input keypresses and mouse activity
@@ -435,6 +435,12 @@ public:
 
     int mouseAutohideDelay() const { return _mouseAutohideDelay; }
 
+    /**
+    * hide the mouse cursor after @param delay milliseconds of inactivity
+    * @param delay < 0 deactivates the behavior
+    */
+    void autoHideMouseAfter(int delay);
+
 public slots:
 
     /**
@@ -528,12 +534,6 @@ public slots:
      */
     void setForegroundColor(const QColor& color);
 
-    /**
-    * hide the mouse cursor after @param delay milliseconds of inactivity
-    * @param delay < 0 deactivates the behavior
-    */
-    void autoHideMouseAfter(int delay);
-
     void selectionChanged();
 
 signals:
@@ -596,6 +596,8 @@ protected:
     virtual void fontChange(const QFont &font);
     void focusInEvent(QFocusEvent* event) override;
     void focusOutEvent(QFocusEvent* event) override;
+    void enterEvent(QEnterEvent* event) override;
+    void leaveEvent(QEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* ev) override;
     void mousePressEvent( QMouseEvent* ) override;
@@ -795,7 +797,7 @@ private:
     bool    _columnSelectionMode;
 
     QClipboard*  _clipboard;
-    QScrollBar* _scrollBar;
+    ScrollBar* _scrollBar;
     QTermWidget::ScrollBarPosition _scrollbarLocation;
     QString     _wordCharacters;
     int         _bellMode;
@@ -894,6 +896,16 @@ protected:
 private:
     QWidget* widget() const { return static_cast<QWidget*>(parent()); }
     int _timerId;
+};
+
+class ScrollBar : public QScrollBar
+{
+Q_OBJECT
+
+public:
+    ScrollBar(QWidget* parent = nullptr);
+protected:
+    void enterEvent(QEnterEvent* event) override;
 };
 
 }

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -832,8 +832,12 @@ void QTermWidget::setWordCharacters(const QString& chars)
     m_impl->m_terminalDisplay->setWordCharacters(chars);
 }
 
-
 QTermWidgetInterface* QTermWidget::createWidget(int startnow) const
 {
    return new QTermWidget(startnow);
+}
+
+void QTermWidget::autoHideMouseAfter(int delay)
+{
+    m_impl->m_terminalDisplay->autoHideMouseAfter(delay);
 }

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -259,6 +259,8 @@ public:
     void setWordCharacters(const QString& chars) override;
 
     QTermWidgetInterface *createWidget(int startnow) const override;
+
+    void autoHideMouseAfter(int delay) override;
 signals:
     void finished();
     void copyAvailable(bool);

--- a/lib/qtermwidget_interface.h
+++ b/lib/qtermwidget_interface.h
@@ -101,6 +101,7 @@ class QTermWidgetInterface {
    virtual QString wordCharacters() const = 0;
    virtual void setWordCharacters(const QString& chars) = 0;
    virtual QTermWidgetInterface* createWidget(int startnow) const = 0;
+   virtual void autoHideMouseAfter(int delay) = 0;
 };
 
 #define QTermWidgetInterface_iid "lxqt.qtermwidget.QTermWidgetInterface/1.5"


### PR DESCRIPTION
Mouse cursor auto-hiding was implemented by @luebking: https://github.com/lxqt/qtermwidget/commit/b150d8503cf8694d2cb5a87a0617d7c5fc5eb4b0

Apart from adding mouse auto-hiding to `QTermWidget`, this patch fixes two issues of the above implementation:

 1. `focusInEvent` and `focusOutEvent` weren't good for controlling auto-hiding, because the hidden mouse cursor can be near other widgets of the app (tab, menu-bar, …), in which case, it wasn't shown when put on them. Therefore, `enterEvent`, and `leaveEvent` are used instead.
 2. The scrollbar needed a separate handling because it's a child of `TerminalDisplay`.

NOTE: A related PR for QTerminal will follow this one.

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

