### PR TITLE
Move away from deprecated declarations

### DIFF
--- a/examples/pyqt/main.py
+++ b/examples/pyqt/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-from PyQt5 import QtWidgets
+from PyQt6 import QtWidgets
 from QTermWidget import QTermWidget
 
 

--- a/pyqt/pyproject.toml
+++ b/pyqt/pyproject.toml
@@ -4,7 +4,7 @@
 requires = ["sip", "PyQt-builder"]
 build-backend = "sipbuild.api"
 
-[tool.sip.metadata]
+[project]
 name = "QTermWidget"
 version = "2.2.0"
-requires-dist = ["PyQt6"]
+dependencies = ["PyQt6"]


### PR DESCRIPTION
Fixes https://github.com/lxqt/qtermwidget/issues/593

It builds and the example runs.

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

