### PR TITLE
Fixed URL pattern

### DIFF
--- a/lib/Filter.cpp
+++ b/lib/Filter.cpp
@@ -491,11 +491,11 @@ void UrlFilter::HotSpot::activate(const QString& actionName)
 
 //regexp matches:
 // full url:
-// protocolname:// or www. followed by anything other than whitespaces, <, >, ' or ", and ends before whitespaces, <, >, ', ", ], !, comma and dot
-const QRegularExpression UrlFilter::FullUrlRegExp(QLatin1String("(www\\.(?!\\.)|[a-z][a-z0-9+.-]*://)[^\\s<>'\"]+[^!,\\.\\s<>'\"\\]]"));
+// NOTE: It is supposed that a URL does not end with a punctuation mark, parenthesis, bracket or single-quotation mark.
+const QRegularExpression UrlFilter::FullUrlRegExp(QLatin1String("[A-Za-z0-9_\\-]+://((?!&quot;|&gt;|&lt;)[A-Za-z0-9_.+/\\?\\=~&%#,;!@\\*\'\\-:\\(\\)\\[\\]])+(?<!\\.|\\?|!|:|;|,|\\(|\\)|\\[|\\]|\')"));
 // email address:
 // [word chars, dots or dashes]@[word chars, dots or dashes].[word chars]
-const QRegularExpression UrlFilter::EmailAddressRegExp(QLatin1String("\\b(\\w|\\.|-)+@(\\w|\\.|-)+\\.\\w+\\b"));
+const QRegularExpression UrlFilter::EmailAddressRegExp(QLatin1String("([A-Za-z0-9_.\\-]+@[A-Za-z0-9_\\-]+\\.[A-Za-z0-9.]+)(?<!\\.)"));
 
 // matches full url or email address
 const QRegularExpression UrlFilter::CompleteUrlRegExp(QLatin1Char('(')+FullUrlRegExp.pattern()+QLatin1Char('|')+


### PR DESCRIPTION
I imported it from FeatherPad. I think it's the most practical URL pattern and have used it in FeatherPad without problem for a long time.

Closes https://github.com/lxqt/qtermwidget/issues/559.

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

