### PR TITLE
Fixed disappearance of Open/Copy link actions (in context menu)

### DIFF
--- a/lib/Filter.h
+++ b/lib/Filter.h
@@ -142,7 +142,12 @@ public:
      * Empties the filters internal buffer and resets the line count back to 0.
      * All hotspots are deleted.
      */
-    void reset();
+    virtual void reset();
+
+    /**
+     * Clears the lists of hotspots without deleting hotspots.
+     */
+    void clear();
 
     /** Adds a new line of text to the filter and increments the line count */
     //void addLine(const QString& string);
@@ -229,11 +234,11 @@ public:
 
 protected:
     /**
-     * Called when a match for the regular expression is encountered.  Subclasses should reimplement this
-     * to return custom hotspot types
+     * Called when a match for the regular expression is encountered. Subclasses should reimplement
+     * this to get custom hotspot types and add them to the lists of hotspots.
      */
-    virtual RegExpFilter::HotSpot* newHotSpot(int startLine,int startColumn,
-                                    int endLine,int endColumn);
+    virtual void newHotSpot(int startLine, int startColumn, int endLine, int endColumn,
+                            const QStringList& captureList);
 
 private:
     QRegularExpression _searchText;
@@ -282,9 +287,14 @@ public:
     };
 
     UrlFilter();
+    ~UrlFilter() override;
+
+    void process() override;
+
+    void reset() override;
 
 protected:
-    RegExpFilter::HotSpot* newHotSpot(int,int,int,int) override;
+    void newHotSpot(int, int, int, int, const QStringList&) override;
 
 private:
 
@@ -293,6 +303,8 @@ private:
 
     // combined OR of FullUrlRegExp and EmailAddressRegExp
     static const QRegularExpression CompleteUrlRegExp;
+
+    QList<UrlFilter::HotSpot*> _oldHotspotList;
 signals:
     void activated(const QUrl& url, bool fromContextMenu);
 };


### PR DESCRIPTION
The patch deletes only invalid URLs (hotspots), if any, after processing is finished, instead of deleting all URLs and recreating the valid ones. In this way, the valid Open & Copy actions are kept when the terminal contents are processed.

Fixes https://github.com/lxqt/qterminal/issues/358

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

