### PR TITLE
Fix qtermwidget_version.h output path for subproject use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ configure_file(
 
 configure_file(
     "${PROJECT_SOURCE_DIR}/lib/qtermwidget_version.h.in"
-    "${CMAKE_BINARY_DIR}/lib/qtermwidget_version.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/lib/qtermwidget_version.h"
     @ONLY
 )
 


### PR DESCRIPTION
Update output path for qtermwidget_version.h so that QTermWidget can be built as a CMake subproject.

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

