### PR TITLE
Add Nord theme

### DIFF
--- a/lib/color-schemes/Nord.colorscheme
+++ b/lib/color-schemes/Nord.colorscheme
@@ -1,5 +1,5 @@
 # Copyright (c) 2016-present Sven Greb <development@svengreb.de>
-# This source code is licensed under the MIT license found in the license file.
+# This source code is licensed under the MIT license.
 
 [Background]
 Color=46,52,64


### PR DESCRIPTION
Taken from https://raw.githubusercontent.com/nordtheme/konsole/refs/heads/develop/src/nord.colorscheme

This theme is relatively popular, so perhaps we can bundle it the way we do Solarized. The Nord thene is MIT-licensed. MIT is GPL-compatible:

- qtermwidget can include MIT-licensed files inside a GPL-licensed repository/distribution.
- The combined distribution may be under the GPL, but the MIT file itself remains MIT-licensed

See https://fossa.com/blog/open-source-licenses-101-mit-license/

> Is the MIT License compatible with GPL? Yes, the MIT License is compatible with GPL. You can combine MIT-licensed code with GPL-licensed code, but the resulting work must be licensed under GPL due to GPL's copyleft requirements.