### PR TITLE
Do not emit `titleChanged` on OSC 7

### DIFF
--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -377,7 +377,6 @@ void Session::setUserTitle( int what, const QString & caption )
     if (what == 7) {
         _reportedWorkingUrl = QUrl::fromUserInput(caption);
         emit currentDirectoryChanged(currentWorkingDirectory());
-        modified = true;
     }
 
     if (what == 11) {


### PR DESCRIPTION
Alternative to https://github.com/lxqt/qterminal/pull/1324. See "Alternative 1" in that PR for a description of this change. I do not have a strong preference.

Closes https://github.com/lxqt/qterminal/pull/1324