### PR TITLE
Call update after setting opacity

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -713,6 +713,7 @@ QColor TerminalDisplay::keyboardCursorColor() const
 void TerminalDisplay::setOpacity(qreal opacity)
 {
     _opacity = qBound(static_cast<qreal>(0), opacity, static_cast<qreal>(1));
+    update();
 }
 
 void TerminalDisplay::setBackgroundImage(const QString& backgroundImage)


### PR DESCRIPTION
## Summary

`setOpacity` sets `_opacity` but never schedules a repaint, so opacity changes have no visible effect until something else triggers one. This adds the missing `update()` call.

In a related fix to the QML fork ([Swordfish90/qmltermwidget#48](https://github.com/Swordfish90/qmltermwidget/pull/48))), I also moved `setOpacity` to `public slots:` so it can be called directly from QML and connected to signals. I didn't include that here since qtermwidget is a pure C++ widget and the existing placement in `public:` is fine.

## Test plan

- [ ] Call `setOpacity()` with a sub-1.0 value and confirm the terminal background renders semi-transparent immediately, without needing any other event to trigger a repaint
- [ ] Confirm full-opacity (`1.0`) rendering is unchanged
