### PR TITLE
emulation: implement DECRQM/DECRPM (request/report mode)

### DIFF
--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -317,6 +317,8 @@ void Vt102Emulation::receiveChar(wchar_t cc)
     if (lec(3,1,'#')) { processToken( TY_ESC_DE(s[2]), 0, 0);           resetTokenizer(); return; }
     if (eps(    CPN)) { processToken( TY_CSI_PN(cc), argv[0],argv[1]);  resetTokenizer(); return; }
     if (esp(       )) { return; }
+    // DECRQM: CSI Pd $ p — absorb '$' intermediate byte and dispatch on 'p'
+    if (eec('$')) { return; } // absorb '$' and wait for final byte
 
     // CSI with '<' private marker (e.g. SGR mouse reporting: CSI < ... M/m).
     // Once ESC[< is seen, consume bytes until a CSI final byte (0x40-0x7E).
@@ -849,6 +851,44 @@ void Vt102Emulation::processToken(int token, wchar_t p, int q)
     //FIXME: weird DEC reset sequence
     case TY_CSI_PE('p'      ) : /* IGNORED: reset         (        ) */ break;
 
+    // DECRQM — Request Mode (Host To Terminal)
+    // When the '$' intermediate byte is absorbed by the tokenizer, the natural
+    // for-loop dispatch produces TY_CSI_PR('p',N) for DEC private modes and
+    // TY_CSI_PS('p',N) for ANSI modes — same token types konsole uses.
+    //
+    // ANSI mode queries: CSI Pd $ p  →  TY_CSI_PS('p', Pd)
+    // NOTE: Screen-owned modes (values < MODES_SCREEN=6) must be queried
+    // via _currentScreen->getMode() since Screen::reset() initialises them
+    // independently of the emulation's _currentModes (which starts zeroed).
+    case TY_CSI_PS('p',   2) : reportAnsiMode( 2, 2); break; // KAM (Keyboard Action) - Not supported
+    case TY_CSI_PS('p',   4) : reportAnsiMode( 4, _currentScreen->getMode(MODE_Insert) ? 1 : 2); break; // IRM
+    case TY_CSI_PS('p',  10) : reportAnsiMode(10, 4); break; // HEM (Horizontal Editing) - Permanently reset
+    case TY_CSI_PS('p',  20) : reportAnsiMode(20, getMode(MODE_NewLine) ? 1 : 2); break; // LNM
+
+    // DEC private mode queries: CSI ? Pd $ p  →  TY_CSI_PR('p', Pd)
+    case TY_CSI_PR('p',   1) : reportDecMode(  1, getMode(MODE_AppCuKeys) ? 1 : 2); break; // DECCKM
+    case TY_CSI_PR('p',   2) : reportDecMode(  2, getMode(MODE_Ansi) ? 1 : 2);      break; // DECANM
+    case TY_CSI_PR('p',   3) : reportDecMode(  3, getMode(MODE_132Columns) ? 1 : 2); break; // DECCOLM
+    case TY_CSI_PR('p',   4) : reportDecMode(  4, 4); break; // DECSCLM (Scrolling) - Permanently reset
+    case TY_CSI_PR('p',   5) : reportDecMode(  5, _currentScreen->getMode(MODE_Screen) ? 1 : 2); break; // DECSCNM
+    case TY_CSI_PR('p',   6) : reportDecMode(  6, _currentScreen->getMode(MODE_Origin) ? 1 : 2); break; // DECOM
+    case TY_CSI_PR('p',   7) : reportDecMode(  7, _currentScreen->getMode(MODE_Wrap) ? 1 : 2);   break; // DECAWM
+    case TY_CSI_PR('p',   8) : reportDecMode(  8, 4); break; // DECARM (Autorepeat) - Permanently reset
+    case TY_CSI_PR('p',   9) : reportDecMode(  9, 4); break; // DECINLM (Interlace) - Permanently reset
+    case TY_CSI_PR('p',  10) : reportDecMode( 10, 4); break; // DECEDM (Edit Mode) - Permanently reset
+    case TY_CSI_PR('p',  25) : reportDecMode( 25, _currentScreen->getMode(MODE_Cursor) ? 1 : 2); break; // DECTCEM
+    case TY_CSI_PR('p',  47) : reportDecMode( 47, getMode(MODE_AppScreen) ? 1 : 2);            break; // Alt screen
+    case TY_CSI_PR('p', 1000) : reportDecMode(1000, getMode(MODE_Mouse1000) ? 1 : 2);          break; // VT200 mouse
+    case TY_CSI_PR('p', 1002) : reportDecMode(1002, getMode(MODE_Mouse1002) ? 1 : 2);          break; // Cell motion mouse
+    case TY_CSI_PR('p', 1003) : reportDecMode(1003, getMode(MODE_Mouse1003) ? 1 : 2);          break; // All motion mouse
+    case TY_CSI_PR('p', 1004) : reportDecMode(1004, _reportFocusEvents ? 1 : 2);               break; // Focus events
+    case TY_CSI_PR('p', 1005) : reportDecMode(1005, getMode(MODE_Mouse1005) ? 1 : 2);          break; // UTF-8 mouse
+    case TY_CSI_PR('p', 1006) : reportDecMode(1006, getMode(MODE_Mouse1006) ? 1 : 2);          break; // SGR mouse
+    case TY_CSI_PR('p', 1015) : reportDecMode(1015, getMode(MODE_Mouse1015) ? 1 : 2);          break; // URXVT mouse
+    case TY_CSI_PR('p', 1047) : reportDecMode(1047, getMode(MODE_AppScreen) ? 1 : 2);          break; // Alt screen (xterm)
+    case TY_CSI_PR('p', 1049) : reportDecMode(1049, getMode(MODE_AppScreen) ? 1 : 2);          break; // Alt screen + cursor
+    case TY_CSI_PR('p', 2004) : reportDecMode(2004, getMode(MODE_BracketedPaste) ? 1 : 2);     break; // Bracketed paste
+
     //FIXME: when changing between vt52 and ansi mode evtl do some resetting.
     case TY_VT52('A'      ) : _currentScreen->cursorUp             (         1); break; //VT52
     case TY_VT52('B'      ) : _currentScreen->cursorDown           (         1); break; //VT52
@@ -946,6 +986,31 @@ void Vt102Emulation::reportStatus()
 {
   sendString("\033[0n"); //VT100. Device status report. 0 = Ready.
 }
+
+// DECRPM — Report Mode (Terminal To Host), response to DECRQM
+// Responds to an ANSI mode query (CSI Pd $ p) with: CSI Pd ; Pm $ y
+void Vt102Emulation::reportAnsiMode(int mode, int status)
+{
+    const size_t sz = 32;
+    char tmp[sz];
+    const size_t r = snprintf(tmp, sz, "\033[%d;%d$y", mode, status);
+    if (sz <= r)
+        qWarning("Vt102Emulation::reportAnsiMode: Buffer too small\n");
+    sendString(tmp);
+}
+
+// DECRPM — Report Mode (Terminal To Host), response to DECRQM
+// Responds to a DEC private mode query (CSI ? Pd $ p) with: CSI ? Pd ; Pm $ y
+void Vt102Emulation::reportDecMode(int mode, int status)
+{
+    const size_t sz = 32;
+    char tmp[sz];
+    const size_t r = snprintf(tmp, sz, "\033[?%d;%d$y", mode, status);
+    if (sz <= r)
+        qWarning("Vt102Emulation::reportDecMode: Buffer too small\n");
+    sendString(tmp);
+}
+
 
 void Vt102Emulation::reportAnswerBack()
 {

--- a/lib/Vt102Emulation.h
+++ b/lib/Vt102Emulation.h
@@ -162,6 +162,9 @@ private:
   void reportAnswerBack();
   void reportCursorPosition();
   void reportTerminalParms(int p);
+  // DECRPM responses to DECRQM queries
+  void reportAnsiMode(int mode, int status);
+  void reportDecMode(int mode, int status);
 
   void onScrollLock();
   void scrollLock(const bool lock);


### PR DESCRIPTION
Handle DECRQM mode queries by reusing the existing CSI token types and return DECRPM replies for the ANSI and DEC modes qtermwidget already tracks.

Implementation details:
- absorb the '$' CSI intermediate byte and dispatch on the following 'p' final byte through the existing TY_CSI_PS/TY_CSI_PR paths
- add reportAnsiMode() and reportDecMode() helpers
- report tracked ANSI modes: KAM (2), IRM (4), HEM (10, permanently reset), LNM (20)
- report tracked DEC modes: DECCKM (1), DECANM (2), DECCOLM (3), DECSCLM (4, permanently reset), DECSCNM (5), DECOM (6), DECAWM (7), DECARM/DECINLM/DECEDM (8/9/10, permanently reset), DECTCEM (25), alt screen (47/1047/1049), mouse modes (1000/1002/1003/1005/1006/1015), focus events (1004), and bracketed paste (2004)

doc: https://vt100.net/docs/vt510-rm/DECRQM.html
