### PR TITLE
Support Shift+click to select a range

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2091,21 +2091,27 @@ void TerminalDisplay::mousePressEvent(QMouseEvent* ev)
 
   if ( ev->button() == Qt::LeftButton)
   {
+    // Shift+click extends the selection, but only for programs not interested in mouse.
+    if (_mouseMarks && (ev->modifiers() & Qt::ShiftModifier)) {
+      extendSelection(ev->position().toPoint());
+      return;
+    }
+
     _lineSelectionMode = false;
     _wordSelectionMode = false;
 
     emit isBusySelecting(true); // Keep it steady...
-    // Drag only when the Control key is hold
     bool selected = false;
 
     // The receiver of the testIsSelected() signal will adjust
     // 'selected' accordingly.
     //emit testIsSelected(pos.x(), pos.y(), selected);
 
+    // The user clicked inside selected text
     selected =  _screenWindow->isSelected(pos.x(),pos.y());
 
+    // Drag only when the Control key is hold
     if ((!_ctrlDrag || ev->modifiers() & Qt::ControlModifier) && selected ) {
-      // The user clicked inside selected text
       dragInfo.state = diPending;
       dragInfo.start = ev->pos();
     }


### PR DESCRIPTION
When a start anchor selected, which may be by a plain click (char mode), a double click (word mode) or a triple click (line mode), another Shift+click extends the selection from the start anchor to the clicked position, which may be further extended in word and line mode.  This range selection behavior is seen in most common terminals, including at least Konsole and VTE-based ones.

This patch is derived from an old version of Konsole, see commits:
- Implement Shift+click to extend selection https://github.com/KDE/konsole/commit/9a3d588d0e9abf2b01bf769c88bc3fafbe65ccd8
- Fix 'extend Selection' bug for apps not interested in mouse https://github.com/KDE/konsole/commit/e5b7480966f3121f4e1042648e29a74b9c29b2e9

While there, moved two comments to the right place.

Issue: https://github.com/lxqt/qterminal/issues/818
Assisted-by: Claude Sonnet 4.6 (https://claude.ai/)

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

