### PR TITLE
fix: preserve scroll position when terminal shrinks

### DIFF
--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -320,6 +320,7 @@ void Emulation::showBulk()
 
     _currentScreen->resetScrolledLines();
     _currentScreen->resetDroppedLines();
+    _currentScreen->resetResizePushedLines();
 }
 
 void Emulation::bufferedUpdate()

--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -70,6 +70,7 @@ Character Screen::defaultChar = Character(' ',
     screenLines(new ImageLine[lines+1] ),
     _scrolledLines(0),
     _droppedLines(0),
+    _resizePushedLines(0),
     history(new HistoryScrollNone()),
     cuX(0), cuY(0),
     currentRendition(0),
@@ -349,6 +350,7 @@ void Screen::resizeImage(int new_lines, int new_columns)
         for (int i = 0; i < cuY-(new_lines-1); i++)
         {
             addHistLine(); scrollUp(0,1);
+            ++_resizePushedLines;
         }
     }
 
@@ -883,6 +885,14 @@ void Screen::resetDroppedLines()
 void Screen::resetScrolledLines()
 {
     _scrolledLines = 0;
+}
+int Screen::resizePushedLines() const
+{
+    return _resizePushedLines;
+}
+void Screen::resetResizePushedLines()
+{
+    _resizePushedLines = 0;
 }
 
 void Screen::scrollUp(int n)

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -555,6 +555,9 @@ public:
      */
     void resetDroppedLines();
 
+    int resizePushedLines() const;
+    void resetResizePushedLines();
+
     /**
       * Fills the buffer @p dest with @p count instances of the default (ie. blank)
       * Character style.
@@ -647,6 +650,7 @@ private:
     QRect _lastScrolledRegion;
 
     int _droppedLines;
+    int _resizePushedLines;
 
     QVarLengthArray<LineProperty,64> lineProperties;
 

--- a/lib/ScreenWindow.cpp
+++ b/lib/ScreenWindow.cpp
@@ -282,6 +282,12 @@ void ScreenWindow::notifyOutputChanged()
         _currentLine = qMax(0,_currentLine -
                               _screen->droppedLines());
 
+        // When the terminal shrinks, resizeImage() pushes excess screen
+        // lines into history to keep the cursor in view.  Advance
+        // _currentLine by the same amount so the viewport stays
+        // bottom-anchored instead of jumping towards the top.
+        _currentLine += _screen->resizePushedLines();
+
         // ensure that the screen window's current position does
         // not go beyond the bottom of the screen
         _currentLine = qMin( _currentLine , _screen->getHistLines() );


### PR DESCRIPTION
## Summary

- When the terminal shrinks vertically, `Screen::resizeImage()` pushes excess screen lines into history to keep the cursor in view. `ScreenWindow::notifyOutputChanged()` adjusts `_currentLine` for dropped lines (history overflow) but not for these resize-pushed lines in the non-tracking-output path, causing the viewport to jump towards the top of the scrollback.
- Track pushed lines in a new `_resizePushedLines` counter, advance `_currentLine` by that amount in the non-tracking path, reset in `showBulk()`.

## Reproduction

1. Open qterminal, run a command that produces lots of output
2. Scroll up to the middle of the scrollback
3. Shrink the terminal window vertically by dragging the bottom edge
4. Observe the scrollbar thumb jumps towards the top instead of staying anchored

## Test plan

- [ ] Shrink terminal while scrolled up in scrollback — viewport should stay anchored
- [ ] Shrink terminal while at bottom (tracking output) — should stay at bottom
- [ ] Rapid resizes (drag edge quickly) — no drift due to accumulated pushes
- [ ] History-limited terminal filling up during resize — droppedLines still handled correctly