### PR TITLE
update fsf address

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
                        Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/lib/Emulation.h
+++ b/lib/Emulation.h
@@ -15,9 +15,8 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-    02110-1301  USA.
+    along with this program; if not, see
+    <https://www.gnu.org/licenses/>.
 */
 
 #ifndef EMULATION_H

--- a/lib/Filter.h
+++ b/lib/Filter.h
@@ -12,9 +12,8 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-    02110-1301  USA.
+    along with this program; if not, see
+    <https://www.gnu.org/licenses/>.
 */
 
 #ifndef FILTER_H

--- a/lib/KeyboardTranslator.h
+++ b/lib/KeyboardTranslator.h
@@ -14,9 +14,8 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-    02110-1301  USA.
+    along with this program; if not, see
+    <https://www.gnu.org/licenses/>.
 */
 
 #ifndef KEYBOARDTRANSLATOR_H

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -11,9 +11,8 @@
     Library General Public License for more details.
 
     You should have received a copy of the GNU Library General Public License
-    along with this library; see the file COPYING.LIB.  If not, write to
-    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-    Boston, MA 02110-1301, USA.
+    along with this library; see the file COPYING.LIB.  If not, see
+    <https://www.gnu.org/licenses/>.
 */
 
 

--- a/lib/qtermwidget_interface.h
+++ b/lib/qtermwidget_interface.h
@@ -11,9 +11,8 @@
     Library General Public License for more details.
 
     You should have received a copy of the GNU Library General Public License
-    along with this library; see the file COPYING.LIB.  If not, write to
-    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-    Boston, MA 02110-1301, USA.
+    along with this library; see the file COPYING.LIB.  If not, see
+    <https://www.gnu.org/licenses/>.
 */
 
 #pragma once

--- a/lib/qtermwidget_version.h.in
+++ b/lib/qtermwidget_version.h.in
@@ -11,9 +11,8 @@
     Library General Public License for more details.
 
     You should have received a copy of the GNU Library General Public License
-    along with this library; see the file COPYING.LIB.  If not, write to
-    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-    Boston, MA 02110-1301, USA.
+    along with this library; see the file COPYING.LIB.  If not, see
+    <https://www.gnu.org/licenses/>.
 */
 
 


### PR DESCRIPTION
See https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html for the most current published address

On rpm based systems, when building, the old fsf address throws an Error in rpmlint.

This PR doesn't change any functionality, it's completely administrative.

