### PR TITLE
Removed debug from `TerminalDisplay::loc`

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -107,15 +107,15 @@ const QChar LTR_OVERRIDE_CHAR( 0x202D );
 
 inline int TerminalDisplay::loc(int x, int y) const
 {
-    if (y < 0 || y > _lines) {
-        qDebug() << "Y: " << y << "Lines" << _lines;
-    }
-    if (x < 0 || x > _columns) {
-        qDebug() << "X" << x << "Columns" << _columns;
-    }
+    // if (y < 0 || y >= _lines) {
+    //     qDebug() << "Y: " << y << "Lines" << _lines;
+    // }
+    // if (x < 0 || x >= _columns) {
+    //     qDebug() << "X" << x << "Columns" << _columns;
+    // }
+    // Q_ASSERT(y >= 0 && y < _lines);
+    // Q_ASSERT(x >= 0 && x < _columns);
 
-    Q_ASSERT(y >= 0 && y < _lines);
-    Q_ASSERT(x >= 0 && x < _columns);
     x = qBound(0, x, _columns - 1);
     y = qBound(0, y, _lines - 1);
 


### PR DESCRIPTION
IMO the total logic is correct but this debug message isn't: it was always shown when the selection end was beyond the visible part of the text. Hence commenting it out.

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

