### PR TITLE
Fix TerminalDisplay::extendSelection() to avoid loc() assertions

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -107,12 +107,13 @@ const QChar LTR_OVERRIDE_CHAR( 0x202D );
 
 inline int TerminalDisplay::loc(int x, int y) const
 {
-    // if (y < 0 || y >= _lines) {
-    //     qDebug() << "Y: " << y << "Lines" << _lines;
-    // }
-    // if (x < 0 || x >= _columns) {
-    //     qDebug() << "X" << x << "Columns" << _columns;
-    // }
+    if (y < 0 || y >= _lines) {
+        qWarning() << "loc(): Y:" << y << ", Lines:" << _lines;
+    }
+    if (x < 0 || x >= _columns) {
+        qWarning() << "loc(): X:" << x << ", Columns:" << _columns;
+    }
+
     // Q_ASSERT(y >= 0 && y < _lines);
     // Q_ASSERT(x >= 0 && x < _columns);
 

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -2447,9 +2447,6 @@ void TerminalDisplay::extendSelection( const QPoint& position )
   int offset = 0;
   if ( !_wordSelectionMode && !_lineSelectionMode )
   {
-    int i;
-    QChar selClass;
-
     bool left_not_right = ( here.y() < _iPntSelCorr.y() ||
        ( here.y() == _iPntSelCorr.y() && here.x() < _iPntSelCorr.x() ) );
     bool old_left_not_right = ( _pntSelCorr.y() < _iPntSelCorr.y() ||
@@ -2458,26 +2455,8 @@ void TerminalDisplay::extendSelection( const QPoint& position )
 
     // Find left (left_not_right ? from here : from start)
     QPoint left = left_not_right ? here : _iPntSelCorr;
-
-    // Find left (left_not_right ? from start : from here)
+    // Find right (left_not_right ? from start : from here)
     QPoint right = left_not_right ? _iPntSelCorr : here;
-    if ( right.x() > 0 && !_columnSelectionMode )
-    {
-      i = loc(right.x(),right.y());
-      if (i>=0 && i<=_imageSize) {
-        selClass = charClass(_image[i-1]);
-       /* if (selClass == ' ')
-        {
-          while ( right.x() < _usedColumns-1 && charClass(_image[i+1]) == selClass && (right.y()<_usedLines-1) &&
-                          !(_lineProperties[right.y()] & LINE_WRAPPED))
-          { i++; right.rx()++; }
-          if (right.x() < _usedColumns-1)
-            right = left_not_right ? _iPntSelCorr : here;
-          else
-            right.rx()++;  // will be balanced later because of offset=-1;
-        }*/
-      }
-    }
 
     // Pick which is start (ohere) and which is extension (here)
     if ( left_not_right )
@@ -2504,7 +2483,6 @@ void TerminalDisplay::extendSelection( const QPoint& position )
     {
         _screenWindow->setSelectionStart( ohere.x()-1-offset , ohere.y() , false );
     }
-
   }
 
   _actSel = 2; // within selection
@@ -2519,7 +2497,6 @@ void TerminalDisplay::extendSelection( const QPoint& position )
   {
      _screenWindow->setSelectionEnd( here.x()+offset , here.y() );
   }
-
 }
 
 void TerminalDisplay::mouseReleaseEvent(QMouseEvent* ev)


### PR DESCRIPTION
This PR fixes the `TerminalDisplay::loc()` assertion that could be triggered by char-mode range selection, which was also discussed in PR #641.

As a result, revert the change of PR #641.