### PR TITLE
Parse VT100 ECMA-48 Control Strings: DCS, APC, PM, SOS

### DIFF
--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -258,9 +258,9 @@ void Vt102Emulation::initTokenizer()
 #define eeq( )     (p >=  3  && s[2] == '=')
 #define egt( )     (p >=  3  && s[2] == '>')
 #define esp( )     (p ==  4  && s[3] == ' ')
-#define Xpe        (tokenBufferPos >= 2 && (tokenBuffer[1] == ']' || tokenBuffer[1] == 'P' || tokenBuffer[1] == '_' || tokenBuffer[1] == '^' || tokenBuffer[1] == 'X'))
-#define Xte        (Xpe      && ((tokenBuffer[1] == ']' && cc == 7) || (prevCC == 27 && cc == 92) )) // 27, 92 => "\e\\" (ST, String Terminator); BEL only for OSC
-#define ces(C)     (cc < 256 && (charClass[cc] & (C)) == (C) && !Xte)
+#define Cse        (tokenBufferPos >= 2 && (tokenBuffer[1] == ']' || tokenBuffer[1] == 'P' || tokenBuffer[1] == '_' || tokenBuffer[1] == '^' || tokenBuffer[1] == 'X'))
+#define Cte        (Cse      && ((tokenBuffer[1] == ']' && cc == 7) || (prevCC == 27 && cc == 92) )) // 27, 92 => "\e\\" (ST, String Terminator); BEL only for OSC
+#define ces(C)     (cc < 256 && (charClass[cc] & (C)) == (C) && !Cte)
 
 #define CNTL(c) ((c)-'@')
 #define ESC 27
@@ -274,11 +274,11 @@ void Vt102Emulation::receiveChar(wchar_t cc)
 
   if (ces(CTL))
   {
-    // ignore control characters in the text part of Xpe escape sequences, aka: OSC "ESC]", DCS
+    // ignore control characters in the text part of Cse escape sequences, aka: OSC "ESC]", DCS
     // "ESCP", APC "ESC_", SOS "ESCX", and PM  "ESC^".  This matches ECMA-48 5.6 Control strings and
     // XTerm ctlseqs.html, Section "VT100 Mode", heading "Controls beginning with ESC"
-    if (Xpe) {
-        // Store in prevCC so Xte can detect the ST terminator (prevCC == 27 && cc == 92 => ESC \).
+    if (Cse) {
+        // Store in prevCC so Cte can detect the ST terminator (prevCC == 27 && cc == 92 => ESC \).
         //
         // Unterminated strings freeze the parser. Unlike Konsole and xterm which feature state
         // tracking, RIS (\033c) cannot interrupt string mode, e.g. '\x1b]0;OSC-NO-TERM \033c' does
@@ -310,13 +310,13 @@ void Vt102Emulation::receiveChar(wchar_t cc)
     if (lec(1,0,ESC)) { return; }
     if (lec(1,0,ESC+128)) { s[0] = ESC; receiveChar('['); return; }
     if (les(2,1,GRP)) { return; }
-    if (Xte         ) {
+    if (Cte         ) {
         if (tokenBufferPos >= 2 && tokenBuffer[1] == ']')
             processWindowAttributeChange();
         resetTokenizer();
         return;
     }
-    if (Xpe         ) { prevCC = cc; return; }
+    if (Cse         ) { prevCC = cc; return; }
     if (lec(3,2,'?')) { return; }
     if (lec(3,2,'>')) { return; }
     if (lec(3,2,'!')) { return; }

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -259,7 +259,7 @@ void Vt102Emulation::initTokenizer()
 #define egt( )     (p >=  3  && s[2] == '>')
 #define esp( )     (p ==  4  && s[3] == ' ')
 #define Xpe        (tokenBufferPos >= 2 && (tokenBuffer[1] == ']' || tokenBuffer[1] == 'P' || tokenBuffer[1] == '_' || tokenBuffer[1] == '^' || tokenBuffer[1] == 'X'))
-#define Xte        (Xpe      && (cc ==  7 || (prevCC == 27 && cc == 92) )) // 27, 92 => "\e\\" (ST, String Terminator)
+#define Xte        (Xpe      && ((tokenBuffer[1] == ']' && cc == 7) || (prevCC == 27 && cc == 92) )) // 27, 92 => "\e\\" (ST, String Terminator); BEL only for OSC
 #define ces(C)     (cc < 256 && (charClass[cc] & (C)) == (C) && !Xte)
 
 #define CNTL(c) ((c)-'@')
@@ -274,11 +274,26 @@ void Vt102Emulation::receiveChar(wchar_t cc)
 
   if (ces(CTL))
   {
-    // ignore control characters in the text part of Xpe (aka OSC) "ESC]"
-    // escape sequences; this matches what XTERM docs say
+    // ignore control characters in the text part of Xpe escape sequences, aka:
+    // - OSC "ESC]"
+    // - DCS "ESCP"
+    // - APC "ESC_"
+    // - SOS "ESCX"
+    // - PM  "ESC^"
+    // this matches ECMA-48 5.6 Control strings and XTerm ctlseqs.html, Section "VT100 Mode",
+    // heading "Controls beginning with ESC"
     if (Xpe) {
-        prevCC = cc;
-        return;
+        // Allow ESC to interrupt string mode so RIS (\033c) and other
+        // escape sequences can recover from unterminated strings.
+        // This matches Konsole's behavior: ESC unconditionally interrupts
+        // string mode.  CAN/SUB are deliberately ignored (Konsole has
+        // always done so, differing from xterm/VT240).
+        if (cc == ESC) {
+            resetTokenizer();
+        } else {
+            prevCC = cc;
+            return;
+        }
     }
 
     // DEC HACK ALERT! Control Characters are allowed *within* esc sequences in VT100

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -221,7 +221,7 @@ void Vt102Emulation::initTokenizer()
     charClass[*s] |= DIG;
   for(s = (quint8*)"()+*%"; *s; ++s)
     charClass[*s] |= SCS;
-  for(s = (quint8*)"()+*#[]%"; *s; ++s)
+  for(s = (quint8*)"()+*#[]%_^PX"; *s; ++s)
     charClass[*s] |= GRP;
 
   resetTokenizer();
@@ -258,7 +258,7 @@ void Vt102Emulation::initTokenizer()
 #define eeq( )     (p >=  3  && s[2] == '=')
 #define egt( )     (p >=  3  && s[2] == '>')
 #define esp( )     (p ==  4  && s[3] == ' ')
-#define Xpe        (tokenBufferPos >= 2 && tokenBuffer[1] == ']')
+#define Xpe        (tokenBufferPos >= 2 && (tokenBuffer[1] == ']' || tokenBuffer[1] == 'P' || tokenBuffer[1] == '_' || tokenBuffer[1] == '^' || tokenBuffer[1] == 'X'))
 #define Xte        (Xpe      && (cc ==  7 || (prevCC == 27 && cc == 92) )) // 27, 92 => "\e\\" (ST, String Terminator)
 #define ces(C)     (cc < 256 && (charClass[cc] & (C)) == (C) && !Xte)
 
@@ -304,7 +304,12 @@ void Vt102Emulation::receiveChar(wchar_t cc)
     if (lec(1,0,ESC)) { return; }
     if (lec(1,0,ESC+128)) { s[0] = ESC; receiveChar('['); return; }
     if (les(2,1,GRP)) { return; }
-    if (Xte         ) { processWindowAttributeChange(); resetTokenizer(); return; }
+    if (Xte         ) {
+        if (tokenBufferPos >= 2 && tokenBuffer[1] == ']')
+            processWindowAttributeChange();
+        resetTokenizer();
+        return;
+    }
     if (Xpe         ) { prevCC = cc; return; }
     if (lec(3,2,'?')) { return; }
     if (lec(3,2,'>')) { return; }

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -274,26 +274,17 @@ void Vt102Emulation::receiveChar(wchar_t cc)
 
   if (ces(CTL))
   {
-    // ignore control characters in the text part of Xpe escape sequences, aka:
-    // - OSC "ESC]"
-    // - DCS "ESCP"
-    // - APC "ESC_"
-    // - SOS "ESCX"
-    // - PM  "ESC^"
-    // this matches ECMA-48 5.6 Control strings and XTerm ctlseqs.html, Section "VT100 Mode",
-    // heading "Controls beginning with ESC"
+    // ignore control characters in the text part of Xpe escape sequences, aka: OSC "ESC]", DCS
+    // "ESCP", APC "ESC_", SOS "ESCX", and PM  "ESC^".  This matches ECMA-48 5.6 Control strings and
+    // XTerm ctlseqs.html, Section "VT100 Mode", heading "Controls beginning with ESC"
     if (Xpe) {
-        // Allow ESC to interrupt string mode so RIS (\033c) and other
-        // escape sequences can recover from unterminated strings.
-        // This matches Konsole's behavior: ESC unconditionally interrupts
-        // string mode.  CAN/SUB are deliberately ignored (Konsole has
-        // always done so, differing from xterm/VT240).
-        if (cc == ESC) {
-            resetTokenizer();
-        } else {
-            prevCC = cc;
-            return;
-        }
+        // Store in prevCC so Xte can detect the ST terminator (prevCC == 27 && cc == 92 => ESC \).
+        //
+        // Unterminated strings freeze the parser. Unlike Konsole and xterm which feature state
+        // tracking, RIS (\033c) cannot interrupt string mode, e.g. '\x1b]0;OSC-NO-TERM \033c' does
+        // not recover the terminal.
+        prevCC = cc;
+        return;
     }
 
     // DEC HACK ALERT! Control Characters are allowed *within* esc sequences in VT100


### PR DESCRIPTION
Problem
-------

QTerminal echoes raw bytes of unrecognized but valid ECMA-48 Control escape sequences (DCS, APC, PM, SOS) to the screen instead of silently consuming them.

For example, [XTGETTCAP](https://codeberg.org/dnkl/foot#xtgettcap) queries are visible, which may be used by TUI/CLI apps to determine colors/24-bit color support, OSC 52 clipboard, underline, keyboard sequences, etc.

These are meant for the terminal emulator, not for display output.

Solution
--------

- Add `'P'` (DCS), `'_'` (APC), `'^'` (PM), and `'X'` (SOS) to the `GRP` character class so they enter string mode
- Extend the `Xpe` macro to recognize all five string initiators.
- Guard `processWindowAttributeChange()` (OSC title/attribute handler) so it only fires for OSC strings; non-OSC strings are silently discarded.

Testing
-------

Here is a demonstration script, and its before and after output::

      #!/bin/bash
      # Tests for ECMA-48 string sequence handling.
      ESC=$'\x1b'
      ST="${ESC}\\"
      BEL=$'\x07'

      send_seq() {
          # $1 = display label, $2 = initiator char (] P _ ^ X), $3 = payload
          local label="$1" init="$2" data="$3" term
          printf '%-3s: ' "$label"
          for term in ST BEL; do
              local term_str
              case $term in
                  ST)  term_str="$ST";;
                  BEL) term_str="$BEL";;
              esac
              printf '%s%s%s%s' "$ESC" "$init" "$data" "$term_str"
          done
          echo
      }

      echo "Each sequence is sent twice using both kinds of terminators."
      echo "A correct terminal emulator should display *nothing* after ':',"
      echo ""

      send_seq "OSC" ']' '0;TEST_OSC'
      send_seq "DCS" 'P' '+qTEST_DCS'
      send_seq "APC" '_' 'TEST_APC'
      send_seq "PM " '^' 'TEST_PM'
      send_seq "SOS" 'X' 'TEST_SOS'


<img width="1464" height="433" alt="qterminal-before-and-after" src="https://github.com/user-attachments/assets/4eef980a-7885-4c42-b16b-675ee8e7f167" />

Details
-------

From https://ecma-international.org/wp-content/uploads/ECMA-48_5th_edition_june_1991.pdf

> 5.6 Control strings
>
> A control string is a string of bit combinations which may occur in the data stream as a logical entity for
> control purposes. A control string consists of an opening delimiter, a command string or a character string,
> and a terminating delimiter, the STRING TERMINATOR (ST).
>
> [..]
>
> a) APPLICATION PROGRAM COMMAND (APC)
> b) DEVICE CONTROL STRING (DCS)
> c) OPERATING SYSTEM COMMAND (OSC)
> d) PRIVACY MESSAGE (PM)
> e) START OF STRING (SOS)

(OSC already implemented)

These are all described by XTerm as VT100 Mode Controls beginning with ESC,

APC - https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Application-Program-Command-functions
DCS - https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Device-Control-functions
PM - https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Privacy-Message

and SOS as a C1 (8-Bit) Control character,

SOS - https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-C1-lparen-8-Bit-rparen-Control-Characters