### PR TITLE
Add sixel support. Resolves #552

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+build-nosixel
 .kdev4
 *.pyc
 *.whl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(BUILD_EXAMPLE "Build example application. Default OFF." OFF)
 option(QTERMWIDGET_USE_UTEMPTER "Uses libutempter on Linux or libulog on FreeBSD for login records." OFF)
 option(QTERMWIDGET_BUILD_PYTHON_BINDING "Build python binding" OFF)
 option(USE_UTF8PROC "Use libutf8proc for better Unicode support. Default OFF" OFF)
+set(QTERMWIDGET_USE_SIXEL "AUTO" CACHE STRING "Enable inline sixel graphics via libsixel (AUTO/ON/OFF).")
 
 
 # just change version for releases
@@ -41,6 +42,23 @@ find_package(lxqt2-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 
 if(USE_UTF8PROC)
     find_package(Utf8Proc REQUIRED)
+endif()
+
+# Optional libsixel, detect via pkg-config unless explicitly disabled.
+set(QTERMWIDGET_SIXEL_ENABLED OFF)
+if(NOT QTERMWIDGET_USE_SIXEL STREQUAL "OFF")
+    find_package(PkgConfig)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(SIXEL IMPORTED_TARGET libsixel)
+    endif()
+    if(SIXEL_FOUND)
+        set(QTERMWIDGET_SIXEL_ENABLED ON)
+        message(STATUS "libsixel ${SIXEL_VERSION} found, inline sixel graphics enabled")
+    elseif(QTERMWIDGET_USE_SIXEL STREQUAL "ON")
+        message(FATAL_ERROR "QTERMWIDGET_USE_SIXEL=ON but libsixel was not found via pkg-config")
+    else()
+        message(STATUS "libsixel not found, inline sixel graphics disabled")
+    endif()
 endif()
 
 include(LXQtPreventInSourceBuilds)
@@ -77,6 +95,7 @@ set(SRCS
     lib/qtermwidget.cpp
     lib/Screen.cpp
     lib/ScreenWindow.cpp
+    lib/SixelDecoder.cpp
     lib/SearchBar.cpp
     lib/Session.cpp
     lib/ShellCommand.cpp
@@ -178,6 +197,14 @@ if (QTERMWIDGET_USE_UTEMPTER)
         find_library(UTEMPTER_LIB NAMES utempter ulog REQUIRED)
         target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} ${UTEMPTER_LIB})
     endif()
+endif()
+
+if (QTERMWIDGET_SIXEL_ENABLED)
+    target_compile_definitions(${QTERMWIDGET_LIBRARY_NAME}
+        PRIVATE
+            "QTERMWIDGET_SIXEL"
+    )
+    target_link_libraries(${QTERMWIDGET_LIBRARY_NAME} PkgConfig::SIXEL)
 endif()
 
 if (UTF8PROC_FOUND)

--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -51,6 +51,8 @@ using namespace Konsole;
 
 Emulation::Emulation() :
   _currentScreen(nullptr),
+  _cellPixelWidth(0),
+  _cellPixelHeight(0),
   _keyTranslator(nullptr),
   _usesMouse(false),
   _bracketedPasteMode(false),
@@ -74,6 +76,17 @@ Emulation::Emulation() :
     emit titleChanged( 50, QString(QLatin1String("CursorShape=%1;BlinkingCursorEnabled=%2"))
                                .arg(static_cast<int>(cursorShape)).arg(blinkingCursorEnabled) );
   });
+}
+
+void Emulation::setCellPixelSize(int width, int height)
+{
+    _cellPixelWidth  = qMax(0, width);
+    _cellPixelHeight = qMax(0, height);
+}
+
+void Emulation::setBackgroundColor(const QColor& color)
+{
+    _backgroundColor = color;
 }
 
 bool Emulation::programUsesMouse() const

--- a/lib/Emulation.cpp
+++ b/lib/Emulation.cpp
@@ -159,6 +159,12 @@ void Emulation::setScreen(int n)
 void Emulation::clearHistory()
 {
     _screen[0]->setScroll( _screen[0]->getScroll() , false );
+    // `clear` sends ESC[2J ESC[3J — the 2J just scrolls content (including
+    // sixel images) into history, and 3J resets that history. Drop the now-
+    // orphaned image anchors so the visible canvas is actually empty.
+    _screen[0]->clearSixelImages();
+    _screen[1]->clearSixelImages();
+    emit sixelImagesChanged();
 }
 void Emulation::setHistory(const HistoryType& t)
 {

--- a/lib/Emulation.h
+++ b/lib/Emulation.h
@@ -26,6 +26,7 @@
 #include <cstdio>
 
 // Qt
+#include <QColor>
 #include <QKeyEvent>
 //#include <QPointer>
 #include <QTextStream>
@@ -227,6 +228,21 @@ public slots:
 
   /** Change the size of the emulation's image */
   virtual void setImageSize(int lines, int columns);
+
+  /**
+   * Inform the emulation of the pixel dimensions of one terminal cell.
+   * Required by features that translate between pixel and cell coordinates
+   * (e.g. inline sixel graphics). Safe to call repeatedly; the active
+   * TerminalDisplay should call this whenever its font metrics change.
+   */
+  void setCellPixelSize(int width, int height);
+
+  /**
+   * Inform the emulation of the active terminal background color, used to
+   * answer OSC 11 (`ESC ] 11 ; ? BEL`) queries from sixel producers such
+   * that fill unused image regions with the terminal background.
+   */
+  void setBackgroundColor(const QColor& color);
 
   /**
    * Interprets a sequence of characters and sends the result to the terminal.
@@ -461,6 +477,17 @@ protected:
 
   Screen* _currentScreen;  // pointer to the screen which is currently active,
                             // this is one of the elements in the screen[] array
+
+  // Pixel dimensions of a single terminal cell, used by features that need
+  // to translate between pixel- and cell-space (sixel graphics). Updated by
+  // the active TerminalDisplay via setCellPixelSize(); zero before the first
+  // call.
+  int _cellPixelWidth;
+  int _cellPixelHeight;
+
+  // Active terminal background color, kept in sync with the TerminalDisplay
+  // color scheme so OSC 11 queries can be answered with the real bg color.
+  QColor _backgroundColor;
 
   Screen* _screen[2];      // 0 = primary screen ( used by most programs, including the shell
                             //                      scrollbars are enabled in this mode )

--- a/lib/Emulation.h
+++ b/lib/Emulation.h
@@ -362,6 +362,12 @@ signals:
    */
   void outputChanged();
 
+  /** Emitted when the set of inline (sixel) images changes in a way that
+   *  the regular character-buffer diff in updateImage() cannot detect
+   *  (e.g. images dropped on `clear`). The display should force a full
+   *  repaint in response. */
+  void sixelImagesChanged();
+
   /**
    * Emitted when the program running in the terminal wishes to update the
    * session's title.  This also allows terminal programs to customize other

--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -1453,7 +1453,20 @@ void Screen::addHistLine()
         // If the history is full, increment the count
         // of dropped lines
         if ( newHistLines == oldHistLines )
+        {
             _droppedLines++;
+
+            // Shift sixel image anchors down by 1 to track the dropped line,
+            // and prune images whose entire span is now gone.
+            for (auto it = _sixelImages.begin(); it != _sixelImages.end(); )
+            {
+                it->anchorLine -= 1;
+                if (it->anchorLine + it->cellRows <= 0)
+                    it = _sixelImages.erase(it);
+                else
+                    ++it;
+            }
+        }
 
         // Adjust selection for the new point of reference
         if (newHistLines > oldHistLines)
@@ -1533,4 +1546,34 @@ void Screen::fillWithDefaultChar(Character* dest, int count)
 {
     for (int i=0;i<count;i++)
         dest[i] = defaultChar;
+}
+
+void Screen::addSixelImage(QImage image, int cellRows, int cellCols)
+{
+    if (image.isNull() || cellRows <= 0)
+        return;
+
+    SixelImage entry;
+    entry.image        = std::move(image);
+    entry.anchorLine   = static_cast<qint64>(history->getLines()) + cuY;
+    entry.anchorColumn = cuX;
+    entry.cellRows     = cellRows;
+    entry.cellCols     = cellCols;
+    _sixelImages.append(std::move(entry));
+}
+
+QList<SixelImage> Screen::sixelImagesInRange(qint64 firstLine, qint64 lastLine) const
+{
+    QList<SixelImage> result;
+    if (lastLine < firstLine)
+        return result;
+    for (const SixelImage& img : _sixelImages)
+    {
+        const qint64 top    = img.anchorLine;
+        const qint64 bottom = img.anchorLine + img.cellRows - 1;
+        if (bottom < firstLine || top > lastLine)
+            continue;
+        result.append(img);
+    }
+    return result;
 }

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -24,6 +24,7 @@
 #define SCREEN_H
 
 // Qt
+#include <QList>
 #include <QRect>
 #include <QSet>
 #include <QTextStream>
@@ -32,6 +33,7 @@
 // Konsole
 #include "Character.h"
 #include "History.h"
+#include "SixelImage.h"
 
 #define MODE_Origin    0
 #define MODE_Wrap      1
@@ -561,6 +563,23 @@ public:
       */
     static void fillWithDefaultChar(Character* dest, int count);
 
+    /**
+     * Append an inline sixel image at the current cursor position.
+     * The image's anchorLine is set here from the current history+cursor row,
+     * and its anchorColumn from getCursorX().
+     */
+    void addSixelImage(QImage image, int cellRows, int cellCols);
+
+    /**
+     * Return all sixel images whose vertical span intersects the absolute-line
+     * range [firstLine, lastLine] (inclusive). Coordinates are in the same
+     * absolute-line space as ScreenWindow::currentLine().
+     */
+    QList<SixelImage> sixelImagesInRange(qint64 firstLine, qint64 lastLine) const;
+
+    /** Returns all sixel images currently tracked (used by tests/diagnostics). */
+    const QList<SixelImage>& sixelImages() const { return _sixelImages; }
+
     QSet<uint> usedExtendedChars() const
     {
         QSet<uint> result;
@@ -701,6 +720,12 @@ private:
 
     // last position where we added a character
     int lastPos;
+
+    // Inline sixel images, anchored to the same line-index space as
+    // ScreenWindow::currentLine() (0 = oldest history line). When the history
+    // drops a line, every anchor is decremented and fully off-screen images
+    // are pruned.
+    QList<SixelImage> _sixelImages;
 
     // used in REP (repeating char)
     unsigned short lastDrawnChar;

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -580,6 +580,9 @@ public:
     /** Returns all sixel images currently tracked (used by tests/diagnostics). */
     const QList<SixelImage>& sixelImages() const { return _sixelImages; }
 
+    /** Drop all sixel images. */
+    void clearSixelImages() { _sixelImages.clear(); }
+
     QSet<uint> usedExtendedChars() const
     {
         QSet<uint> result;

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -230,6 +230,12 @@ void Session::addView(TerminalDisplay * widget)
         connect(widget, &TerminalDisplay::backgroundColorChanged,
                 _emulation, &Emulation::setBackgroundColor);
 
+        // Force a full repaint when sixel images are dropped (e.g. `clear`):
+        // the character-buffer diff in updateImage() can miss the rows the
+        // image occupied, leaving stale pixels until a focus event.
+        connect(_emulation, &Emulation::sixelImagesChanged,
+                widget, QOverload<>::of(&TerminalDisplay::update));
+
         widget->setScreenWindow(_emulation->createWindow());
     }
 

--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -214,6 +214,22 @@ void Session::addView(TerminalDisplay * widget)
 
         widget->setBracketedPasteMode(_emulation->programBracketedPasteMode());
 
+        // Push the view's current cell pixel size to the emulation, and keep
+        // it in sync when the font metrics change. Used by sixel rendering to
+        // compute how many cell rows a decoded image occupies.
+        _emulation->setCellPixelSize(widget->fontWidth(), widget->fontHeight());
+        connect(widget, &TerminalDisplay::changedFontMetricSignal,
+                _emulation, [this](int h, int w) {
+                    _emulation->setCellPixelSize(w, h);
+                });
+
+        // Push the view's background color so the emulation can answer OSC 11
+        // queries
+        _emulation->setBackgroundColor(
+            widget->colorTable()[DEFAULT_BACK_COLOR].color);
+        connect(widget, &TerminalDisplay::backgroundColorChanged,
+                _emulation, &Emulation::setBackgroundColor);
+
         widget->setScreenWindow(_emulation->createWindow());
     }
 

--- a/lib/SixelDecoder.cpp
+++ b/lib/SixelDecoder.cpp
@@ -1,0 +1,94 @@
+/*
+    This file is part of qtermwidget.
+
+    Copyright 2026 The qtermwidget contributors.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#include "SixelDecoder.h"
+
+#ifdef QTERMWIDGET_SIXEL
+#include <sixel.h>
+#endif
+
+using namespace Konsole;
+
+QImage SixelDecoder::decode(const QByteArray& payload, bool transparentBackground)
+{
+#ifdef QTERMWIDGET_SIXEL
+    if (payload.isEmpty())
+        return QImage();
+
+    unsigned char* pixels  = nullptr;
+    unsigned char* palette = nullptr;
+    int width   = 0;
+    int height  = 0;
+    int ncolors = 0;
+
+    // libsixel's sixel_decode_raw scans for the DCS 'q' final byte before it
+    // starts parsing, pass the canonical DCS envelope (ESC P q <data> ESC \)
+    // around our captured image data, matching what sixel2png feeds it.
+    QByteArray wrapped;
+    wrapped.reserve(payload.size() + 5);
+    wrapped.append("\033Pq", 3);
+    wrapped.append(payload);
+    wrapped.append("\033\\", 2);
+
+    SIXELSTATUS status = sixel_decode_raw(
+        reinterpret_cast<unsigned char*>(wrapped.data()),
+        wrapped.size(),
+        &pixels,
+        &width,
+        &height,
+        &palette,
+        &ncolors,
+        /*allocator=*/nullptr);
+
+    if (SIXEL_FAILED(status) || !pixels || !palette || width <= 0 || height <= 0) {
+        if (pixels)  free(pixels);
+        if (palette) free(palette);
+        return QImage();
+    }
+
+    {
+        FILE* f = fopen("/tmp/sixel-debug.log", "a");
+        if (f) {
+            fprintf(f, "[decoder] ncolors=%d palette[0..7]:", ncolors);
+            for (int n = 0; n < ncolors && n < 8; ++n) {
+                fprintf(f, " (%d,%d,%d)",
+                        palette[n*3+0], palette[n*3+1], palette[n*3+2]);
+            }
+            fprintf(f, "\n");
+            fflush(f);
+            fclose(f);
+        }
+    }
+    QImage img(width, height, QImage::Format_ARGB32);
+    const int total = width * height;
+    for (int i = 0; i < total; ++i) {
+        int idx = pixels[i];
+        if (idx >= ncolors) idx = 0;
+        // libsixel returns the palette as packed RGB (3 bytes per entry),
+        // despite the header's "ARGB palette" comment. Untouched pixels
+        // stay at index 0 (from libsixel's calloc); when the producer
+        // requested P2 == 1, treat them as transparent so the terminal
+        // background shows through.
+        const unsigned char a = (transparentBackground && idx == 0) ? 0 : 0xff;
+        const unsigned char r = palette[idx * 3 + 0];
+        const unsigned char g = palette[idx * 3 + 1];
+        const unsigned char b = palette[idx * 3 + 2];
+        reinterpret_cast<QRgb*>(img.bits())[i] = qRgba(r, g, b, a);
+    }
+
+    free(pixels);
+    free(palette);
+    return img;
+#else
+    Q_UNUSED(payload);
+    return QImage();
+#endif
+}

--- a/lib/SixelDecoder.cpp
+++ b/lib/SixelDecoder.cpp
@@ -54,19 +54,6 @@ QImage SixelDecoder::decode(const QByteArray& payload, bool transparentBackgroun
         return QImage();
     }
 
-    {
-        FILE* f = fopen("/tmp/sixel-debug.log", "a");
-        if (f) {
-            fprintf(f, "[decoder] ncolors=%d palette[0..7]:", ncolors);
-            for (int n = 0; n < ncolors && n < 8; ++n) {
-                fprintf(f, " (%d,%d,%d)",
-                        palette[n*3+0], palette[n*3+1], palette[n*3+2]);
-            }
-            fprintf(f, "\n");
-            fflush(f);
-            fclose(f);
-        }
-    }
     QImage img(width, height, QImage::Format_ARGB32);
     const int total = width * height;
     for (int i = 0; i < total; ++i) {
@@ -89,6 +76,7 @@ QImage SixelDecoder::decode(const QByteArray& payload, bool transparentBackgroun
     return img;
 #else
     Q_UNUSED(payload);
+    Q_UNUSED(transparentBackground);
     return QImage();
 #endif
 }

--- a/lib/SixelDecoder.h
+++ b/lib/SixelDecoder.h
@@ -1,0 +1,37 @@
+/*
+    This file is part of qtermwidget.
+
+    Copyright 2026 The qtermwidget contributors.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#ifndef SIXEL_DECODER_H
+#define SIXEL_DECODER_H
+
+#include <QByteArray>
+#include <QImage>
+
+namespace Konsole
+{
+
+namespace SixelDecoder
+{
+    // Decode a sixel payload (the bytes between "ESC P" and "ESC \",
+    // i.e. parameters and intermediate bytes, the 'q' final, and the
+    // sixel data, *not* including ESC, P, or the terminating ST).
+    //
+    // Returns a null QImage on parse failure or when built without libsixel.
+    //
+    // If transparentBackground is true (DCS P2 == 1), pixels not written by
+    // the sixel data are kept fully transparent so the terminal background
+    // shows through. Otherwise palette index 0 is rendered opaque.
+    QImage decode(const QByteArray& payload, bool transparentBackground);
+}
+
+}
+
+#endif // SIXEL_DECODER_H

--- a/lib/SixelImage.h
+++ b/lib/SixelImage.h
@@ -1,0 +1,36 @@
+/*
+    This file is part of qtermwidget.
+
+    Copyright 2026 The qtermwidget contributors.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+*/
+
+#ifndef SIXEL_IMAGE_H
+#define SIXEL_IMAGE_H
+
+#include <QImage>
+#include <QtGlobal>
+
+namespace Konsole
+{
+
+// A decoded sixel image anchored to an absolute terminal line.
+// The anchor line is "history line index" (0..history->getLines()-1) at
+// emission time; as the history drops lines, the anchor effectively becomes
+// negative and the image is discarded.
+struct SixelImage
+{
+    QImage image;        // ARGB32
+    qint64 anchorLine;   // absolute line index = histLines + cuY at emission
+    int    anchorColumn; // cell column at emission
+    int    cellRows;     // ceil(image.height() / fontHeight) at emission
+    int    cellCols;     // ceil(image.width()  / fontWidth)  at emission
+};
+
+}
+
+#endif // SIXEL_IMAGE_H

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -190,6 +190,7 @@ void TerminalDisplay::setBackgroundColor(const QColor& color)
       _scrollBar->setPalette( QApplication::palette() );
 
     update();
+    emit backgroundColorChanged(color);
 }
 void TerminalDisplay::setForegroundColor(const QColor& color)
 {
@@ -969,6 +970,14 @@ void TerminalDisplay::scrollImage(int lines , const QRect& screenWindowRegion)
     if ( _outputSuspendedLabel && _outputSuspendedLabel->isVisible() )
         return;
 
+    // Sixel images live in the framebuffer at fixed pixel coordinates and
+    // are not part of the character grid that scroll() bitblts. When any
+    // sixel image is stored, force a full widget repaint instead of using
+    // the bitblt path, otherwise image pixels get smeared into rows that
+    // scrolled past them.
+    const bool hasSixelImages = _screenWindow && _screenWindow->screen() &&
+                                !_screenWindow->screen()->sixelImages().isEmpty();
+
     // constrain the region to the display
     // the bottom of the region is capped to the number of lines in the display's
     // internal image - 2, so that the height of 'region' is strictly less
@@ -1056,7 +1065,10 @@ void TerminalDisplay::scrollImage(int lines , const QRect& screenWindowRegion)
     Q_ASSERT(scrollRect.isValid() && !scrollRect.isEmpty());
 
     //scroll the display vertically to match internal _image
-    scroll( 0 , _fontHeight * (-lines) , scrollRect );
+    if (hasSixelImages)
+        update();
+    else
+        scroll( 0 , _fontHeight * (-lines) , scrollRect );
 }
 
 QRegion TerminalDisplay::hotSpotRegion() const
@@ -1533,9 +1545,54 @@ void TerminalDisplay::paintEvent( QPaintEvent* pe )
     drawBackground(paint,*rect,palette().window().color(),
                    true /* use opacity setting */);
     drawContents(paint, *rect);
+    drawSixelImages(paint, *rect);
   }
   drawInputMethodPreeditString(paint,preeditRect());
   paintFilters(paint);
+}
+
+void TerminalDisplay::drawSixelImages(QPainter& paint, const QRect& rect)
+{
+    if (!_screenWindow)
+        return;
+    Screen* screen = _screenWindow->screen();
+    if (!screen || _fontWidth <= 0 || _fontHeight <= 0)
+        return;
+
+    const qint64 windowTop    = _screenWindow->currentLine();
+    const qint64 windowBottom = windowTop + _screenWindow->windowLines() - 1;
+
+    const QList<SixelImage> images = screen->sixelImagesInRange(windowTop, windowBottom);
+    static FILE* paintLog = fopen("/tmp/sixel-debug.log", "a");
+    static int g_sixelDebugTick = 0;
+    if (!screen->sixelImages().isEmpty() && (g_sixelDebugTick++ % 30) == 0 && paintLog) {
+        fprintf(paintLog,
+                "[sixel-paint] total stored=%lld visible=%lld windowTop=%lld windowBottom=%lld\n",
+                static_cast<long long>(screen->sixelImages().size()),
+                static_cast<long long>(images.size()),
+                static_cast<long long>(windowTop),
+                static_cast<long long>(windowBottom));
+        for (const SixelImage& s : screen->sixelImages()) {
+            fprintf(paintLog,
+                    "  image anchor=%lld col=%d cellRows=%d size=%dx%d\n",
+                    static_cast<long long>(s.anchorLine),
+                    s.anchorColumn, s.cellRows, s.image.width(), s.image.height());
+        }
+        fflush(paintLog);
+    }
+    if (images.isEmpty())
+        return;
+
+    paint.save();
+    paint.setClipRect(rect);
+    for (const SixelImage& img : images)
+    {
+        const int x = _leftMargin + img.anchorColumn * _fontWidth;
+        const int y = _topMargin
+                      + static_cast<int>(img.anchorLine - windowTop) * _fontHeight;
+        paint.drawImage(QPoint(x, y), img.image);
+    }
+    paint.restore();
 }
 
 QPoint TerminalDisplay::cursorPosition() const

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -1563,23 +1563,6 @@ void TerminalDisplay::drawSixelImages(QPainter& paint, const QRect& rect)
     const qint64 windowBottom = windowTop + _screenWindow->windowLines() - 1;
 
     const QList<SixelImage> images = screen->sixelImagesInRange(windowTop, windowBottom);
-    static FILE* paintLog = fopen("/tmp/sixel-debug.log", "a");
-    static int g_sixelDebugTick = 0;
-    if (!screen->sixelImages().isEmpty() && (g_sixelDebugTick++ % 30) == 0 && paintLog) {
-        fprintf(paintLog,
-                "[sixel-paint] total stored=%lld visible=%lld windowTop=%lld windowBottom=%lld\n",
-                static_cast<long long>(screen->sixelImages().size()),
-                static_cast<long long>(images.size()),
-                static_cast<long long>(windowTop),
-                static_cast<long long>(windowBottom));
-        for (const SixelImage& s : screen->sixelImages()) {
-            fprintf(paintLog,
-                    "  image anchor=%lld col=%d cellRows=%d size=%dx%d\n",
-                    static_cast<long long>(s.anchorLine),
-                    s.anchorColumn, s.cellRows, s.image.width(), s.image.height());
-        }
-        fflush(paintLog);
-    }
     if (images.isEmpty())
         return;
 

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -553,6 +553,7 @@ signals:
      */
     void mouseSignal(int button, int column, int line, int eventType);
     void changedFontMetricSignal(int height, int width);
+    void backgroundColorChanged(const QColor& color);
     void changedContentSizeSignal(int height, int width);
 
     /**
@@ -666,6 +667,8 @@ private:
     // fragments according to their colors and styles and calls
     // drawTextFragment() to draw the fragments
     void drawContents(QPainter &paint, const QRect &rect);
+    // draws inline sixel images that intersect the dirty 'rect'
+    void drawSixelImages(QPainter &paint, const QRect &rect);
     // draws a section of text, all the text in this section
     // has a common color and style
     void drawTextFragment(QPainter& painter, const QRect& rect,

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -36,16 +36,22 @@
 // Konsole
 #include "KeyboardTranslator.h"
 #include "Screen.h"
+#include "SixelDecoder.h"
 
 
 using namespace Konsole;
+
+static FILE* sixel_log();
+
 
 Vt102Emulation::Vt102Emulation()
     : Emulation(),
      prevCC(0),
      _titleUpdateTimer(new QTimer(this)),
      _reportFocusEvents(false),
-     _toUtf8(QStringEncoder::Utf8)
+     _toUtf8(QStringEncoder::Utf8),
+     _dcsIsSixel(false),
+     _dcsSixelTransparent(false)
 {
   _titleUpdateTimer->setSingleShot(true);
   QObject::connect(_titleUpdateTimer, &QTimer::timeout,
@@ -172,6 +178,8 @@ void Vt102Emulation::resetTokenizer()
   argv[0] = 0;
   argv[1] = 0;
   prevCC = 0;
+  _dcsIsSixel = false;
+  _dcsPayload.clear();
 }
 
 void Vt102Emulation::addDigit(int digit)
@@ -299,8 +307,108 @@ void Vt102Emulation::receiveChar(wchar_t cc)
         return;
     }
   }
+
+  // [debug] log every byte that arrives while inside a Cse string (DCS/OSC/APC/PM/SOS).
+  if (Cse) {
+      FILE* lg = sixel_log();
+      if (lg) {
+          static int cseByteCounter = 0;
+          if (cseByteCounter < 200) {
+              fprintf(lg, "[cse] pos=%d intro='%c'(%d) cc=%d ('%c') prevCC=%d _dcsIsSixel=%d\n",
+                      tokenBufferPos,
+                      tokenBufferPos>=2 ? (char)tokenBuffer[1] : '?',
+                      tokenBufferPos>=2 ? (int)tokenBuffer[1] : 0,
+                      (int)cc, (cc >= 32 && cc < 127) ? (char)cc : '.',
+                      (int)prevCC, _dcsIsSixel ? 1 : 0);
+              fflush(lg);
+              cseByteCounter++;
+          }
+      }
+  }
+  if (Cse && tokenBuffer[1] == 'P' && cc == 'q' && !_dcsIsSixel) {
+      FILE* lg = sixel_log();
+      if (lg) { fprintf(lg, "[sixel] saw 'q' final; tokenBufPos=%d\n", tokenBufferPos); fflush(lg); }
+  }
+
+  // Sixel DCS fast path: once a DCS sequence has been recognised as sixel
+  // (its 'q' final byte was already seen), every subsequent byte goes into
+  // the growable _dcsPayload buffer instead of the fixed-size tokenBuffer.
+  // This must run after the CTL handling above so that ESC inside the
+  // payload still flips prevCC for Cte detection.
+  if (_dcsIsSixel)
+  {
+    if (Cte)
+    {
+        processSixelDcs();
+        _dcsIsSixel = false;
+        _dcsPayload.clear();
+        resetTokenizer();
+        return;
+    }
+    _dcsPayload.append(static_cast<char>(cc & 0xff));
+    prevCC = cc;
+    return;
+  }
+
   // advance the state
   addToCurrentToken(cc);
+
+  // Detect the sixel final byte 'q' while still inside the small-token DCS
+  // parameter scan: switch to the growable payload buffer for everything
+  // that follows. Sixel parameters are restricted to digits and ';' / ':'
+  // digits and ';' / ':', if any intermediate byte (e.g. '$' for DECRQSS) appears in the
+  // parameter run, this is *not* a sixel DCS and must fall through to the
+  // existing short-DCS handler.
+  if (Cse && tokenBuffer[1] == 'P' && cc == 'q')
+  {
+    bool paramsAreSixelCompatible = true;
+    for (int i = 2; i < tokenBufferPos - 1; ++i)
+    {
+        const wchar_t c = tokenBuffer[i];
+        if (!((c >= '0' && c <= '9') || c == ';' || c == ':'))
+        {
+            paramsAreSixelCompatible = false;
+            break;
+        }
+    }
+    if (paramsAreSixelCompatible)
+    {
+        // Sixel image data starts AFTER 'q'. The DCS parameters (P1;P2;P3)
+        // and the 'q' final byte itself must NOT be in the payload.
+        // sixel_decode_raw expects to start parsing at the raster-attribute
+        // byte (`"`), the color introducer (`#`), or a sixel data byte.
+        //
+        // Parse P2 (the second `;`-separated param) to detect the
+        // transparent-background mode.
+        int paramIndex = 0;
+        int paramValue = 0;
+        bool sawDigit = false;
+        int p2 = 0;
+        for (int i = 2; i < tokenBufferPos - 1; ++i)
+        {
+            const wchar_t c = tokenBuffer[i];
+            if (c == ';')
+            {
+                if (paramIndex == 1 && sawDigit) p2 = paramValue;
+                paramIndex++;
+                paramValue = 0;
+                sawDigit = false;
+            }
+            else if (c >= '0' && c <= '9')
+            {
+                paramValue = paramValue * 10 + (c - '0');
+                sawDigit = true;
+            }
+        }
+        if (paramIndex == 1 && sawDigit) p2 = paramValue;
+        _dcsSixelTransparent = (p2 == 1);
+
+        _dcsIsSixel = true;
+        _dcsPayload.clear();
+        prevCC = cc;
+        return;
+    }
+  }
 
   wchar_t* s = tokenBuffer;
   int  p = tokenBufferPos;
@@ -328,7 +436,7 @@ void Vt102Emulation::receiveChar(wchar_t cc)
     if (lec(3,1,'#')) { processToken( TY_ESC_DE(s[2]), 0, 0);           resetTokenizer(); return; }
     if (eps(    CPN)) { processToken( TY_CSI_PN(cc), argv[0],argv[1]);  resetTokenizer(); return; }
     if (esp(       )) { return; }
-    // DECRQM: CSI Pd $ p — absorb '$' intermediate byte and dispatch on 'p'
+    // DECRQM: CSI Pd $ p, absorb '$' intermediate byte and dispatch on 'p'
     if (eec('$')) { return; } // absorb '$' and wait for final byte
 
     // CSI with '<' private marker (e.g. SGR mouse reporting: CSI < ... M/m).
@@ -450,6 +558,34 @@ void Vt102Emulation::processWindowAttributeChange()
     return;
   }
 
+  // OSC 11 ; ?, query terminal background color. This is
+  // used to paint unused regions with the terminal's
+  // background color
+  if (attributeToChange == 11 &&
+      i + 1 < tokenBufferPos &&
+      tokenBuffer[i + 1] == '?' &&
+      _backgroundColor.isValid())
+  {
+    const int r16 = _backgroundColor.red()   * 0x101;
+    const int g16 = _backgroundColor.green() * 0x101;
+    const int b16 = _backgroundColor.blue()  * 0x101;
+    char buf[64];
+    const int n = std::snprintf(buf, sizeof(buf),
+                                "\033]11;rgb:%04x/%04x/%04x\033\\",
+                                r16, g16, b16);
+    if (n > 0) sendString(buf, n);
+    {
+      FILE* lg = sixel_log();
+      if (lg) {
+        fprintf(lg, "[osc11] reply bg=#%02x%02x%02x\n",
+                _backgroundColor.red(), _backgroundColor.green(),
+                _backgroundColor.blue());
+        fflush(lg);
+      }
+    }
+    return;
+  }
+
   // copy from the first char after ';', and skipping the ending delimiter
   // 0x07 or 0x92. Note that as control characters in OSC text parts are
   // ignored, only the second char in ST ("\e\\") is appended to tokenBuffer.
@@ -457,6 +593,77 @@ void Vt102Emulation::processWindowAttributeChange()
 
   _pendingTitleUpdates[attributeToChange] = newValue;
   _titleUpdateTimer->start(20);
+}
+
+static FILE* sixel_log() {
+    static FILE* f = fopen("/tmp/sixel-debug.log", "a");
+    if (f) {
+        static bool wroteHeader = false;
+        if (!wroteHeader) {
+            wroteHeader = true;
+            fprintf(f, "----- sixel log session start -----\n");
+            fflush(f);
+        }
+    }
+    return f;
+}
+
+void Vt102Emulation::processSixelDcs()
+{
+  FILE* lg = sixel_log();
+  if (lg) {
+    fprintf(lg, "[sixel] DCS payload bytes=%lld first32=%s\n",
+            static_cast<long long>(_dcsPayload.size()),
+            _dcsPayload.left(32).toHex().constData());
+    fflush(lg);
+  }
+
+  // Dump payload to a file for offline inspection with sixel2png.
+  {
+    FILE* d = fopen("/tmp/sixel-payload.bin", "wb");
+    if (d) {
+      // Reconstruct the canonical DCS envelope so sixel2png can consume it.
+      fputs("\033Pq", d);
+      fwrite(_dcsPayload.constData(), 1, _dcsPayload.size(), d);
+      fputs("\033\\", d);
+      fclose(d);
+    }
+  }
+  QImage image = SixelDecoder::decode(_dcsPayload, _dcsSixelTransparent);
+  if (image.isNull())
+  {
+    if (lg) { fprintf(lg, "[sixel] decode returned null image\n"); fflush(lg); }
+    return;
+  }
+
+  const int cellW = _cellPixelWidth;
+  const int cellH = _cellPixelHeight;
+  if (cellW <= 0 || cellH <= 0)
+  {
+    if (lg) { fprintf(lg, "[sixel] no cell metrics w=%d h=%d\n", cellW, cellH); fflush(lg); }
+    return;
+  }
+
+  const int cellRows = (image.height() + cellH - 1) / cellH;
+  const int cellCols = (image.width()  + cellW - 1) / cellW;
+  if (lg) {
+    fprintf(lg, "[sixel] decoded %dx%d cellRows=%d cellCols=%d cuY=%d cuX=%d hist=%d\n",
+            image.width(), image.height(), cellRows, cellCols,
+            _currentScreen->getCursorY(), _currentScreen->getCursorX(),
+            _currentScreen->getHistLines());
+    fflush(lg);
+  }
+
+  // Anchor at the current cursor position BEFORE advancing. The anchor is
+  // stored in ScreenWindow line space (0 = oldest history line); subsequent
+  // history scrolling will keep the anchor pointing at the same content
+  // because addHistLine decrements anchors when history drops lines.
+  _currentScreen->addSixelImage(image, cellRows, cellCols);
+
+  // Advance the cursor below the image (DECSDM off, xterm display mode).
+  for (int i = 0; i < cellRows; ++i)
+    _currentScreen->index();
+  _currentScreen->toStartOfLine();
 }
 
 void Vt102Emulation::updateTitle()
@@ -862,10 +1069,10 @@ void Vt102Emulation::processToken(int token, wchar_t p, int q)
     //FIXME: weird DEC reset sequence
     case TY_CSI_PE('p'      ) : /* IGNORED: reset         (        ) */ break;
 
-    // DECRQM — Request Mode (Host To Terminal)
+    // DECRQM, Request Mode (Host To Terminal)
     // When the '$' intermediate byte is absorbed by the tokenizer, the natural
     // for-loop dispatch produces TY_CSI_PR('p',N) for DEC private modes and
-    // TY_CSI_PS('p',N) for ANSI modes — same token types konsole uses.
+    // TY_CSI_PS('p',N) for ANSI modes, same token types konsole uses.
     //
     // ANSI mode queries: CSI Pd $ p  →  TY_CSI_PS('p', Pd)
     // NOTE: Screen-owned modes (values < MODES_SCREEN=6) must be queried
@@ -966,7 +1173,11 @@ void Vt102Emulation::reportTerminalType()
   // VT101:  ^[[?1;0c
   // VT102:  ^[[?6v
   if (getMode(MODE_Ansi))
+#ifdef QTERMWIDGET_SIXEL
+    sendString("\033[?62;4c"); // VT220 with sixel graphics (4)
+#else
     sendString("\033[?1;2c"); // I'm a VT100
+#endif
   else
     sendString("\033/Z"); // I'm a VT52
 }
@@ -998,7 +1209,7 @@ void Vt102Emulation::reportStatus()
   sendString("\033[0n"); //VT100. Device status report. 0 = Ready.
 }
 
-// DECRPM — Report Mode (Terminal To Host), response to DECRQM
+// DECRPM, Report Mode (Terminal To Host), response to DECRQM
 // Responds to an ANSI mode query (CSI Pd $ p) with: CSI Pd ; Pm $ y
 void Vt102Emulation::reportAnsiMode(int mode, int status)
 {
@@ -1010,7 +1221,7 @@ void Vt102Emulation::reportAnsiMode(int mode, int status)
     sendString(tmp);
 }
 
-// DECRPM — Report Mode (Terminal To Host), response to DECRQM
+// DECRPM, Report Mode (Terminal To Host), response to DECRQM
 // Responds to a DEC private mode query (CSI ? Pd $ p) with: CSI ? Pd ; Pm $ y
 void Vt102Emulation::reportDecMode(int mode, int status)
 {

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -479,6 +479,35 @@ void Vt102Emulation::receiveChar(wchar_t cc)
         return;
     }
 
+    // XTSMGRAPHICS: CSI ? Pi ; Pa ; Pv S
+    //   Pi = 1 (color registers), 2 (sixel geometry)
+    //   Pa = 1 read, 2 reset, 3 set, 4 read-max
+    // Reply: CSI ? Pi ; Ps ; Pv S  (Ps = 0 success).
+    // some apps use the color-register reply to pick a palette size
+    // without it apps fall back to numcolors=16
+    if (epp() && cc == 'S' && argc >= 1)
+    {
+        const int pi = argv[0];
+        const int pa = argv[1];
+        char buf[64];
+        int n = 0;
+        if (pi == 1) {
+            const int maxColors = 256;
+            int pv = maxColors;
+            if (pa == 3 && argc >= 2 && argv[2] > 0)
+                pv = qMin(argv[2], maxColors);
+            n = std::snprintf(buf, sizeof(buf), "\033[?1;0;%dS", pv);
+        } else if (pi == 2) {
+            n = std::snprintf(buf, sizeof(buf), "\033[?2;0;%d;%dS", 10000, 10000);
+        } else {
+            // Unknown item: reply with failure status (Ps=1).
+            n = std::snprintf(buf, sizeof(buf), "\033[?%d;1;0S", pi);
+        }
+        if (n > 0) sendString(buf, n);
+        resetTokenizer();
+        return;
+    }
+
     if (epe(   )) { processToken( TY_CSI_PE(cc), 0, 0); resetTokenizer(); return; }
     if (ees(DIG)) { addDigit(cc-'0'); return; }
     if (eec(';') || eec(':')) { addArgument(); return; }
@@ -664,6 +693,11 @@ void Vt102Emulation::processSixelDcs()
   for (int i = 0; i < cellRows; ++i)
     _currentScreen->index();
   _currentScreen->toStartOfLine();
+
+  // The character buffer under the image area is just spaces; updateImage's
+  // diff sees no change in those rows and won't request a repaint, leaving
+  // stale or missing pixels until a focus event forces a full paint.
+  emit sixelImagesChanged();
 }
 
 void Vt102Emulation::updateTitle()

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -41,9 +41,6 @@
 
 using namespace Konsole;
 
-static FILE* sixel_log();
-
-
 Vt102Emulation::Vt102Emulation()
     : Emulation(),
      prevCC(0),
@@ -306,28 +303,6 @@ void Vt102Emulation::receiveChar(wchar_t cc)
         processToken(TY_CTL(cc+'@' ),0,0);
         return;
     }
-  }
-
-  // [debug] log every byte that arrives while inside a Cse string (DCS/OSC/APC/PM/SOS).
-  if (Cse) {
-      FILE* lg = sixel_log();
-      if (lg) {
-          static int cseByteCounter = 0;
-          if (cseByteCounter < 200) {
-              fprintf(lg, "[cse] pos=%d intro='%c'(%d) cc=%d ('%c') prevCC=%d _dcsIsSixel=%d\n",
-                      tokenBufferPos,
-                      tokenBufferPos>=2 ? (char)tokenBuffer[1] : '?',
-                      tokenBufferPos>=2 ? (int)tokenBuffer[1] : 0,
-                      (int)cc, (cc >= 32 && cc < 127) ? (char)cc : '.',
-                      (int)prevCC, _dcsIsSixel ? 1 : 0);
-              fflush(lg);
-              cseByteCounter++;
-          }
-      }
-  }
-  if (Cse && tokenBuffer[1] == 'P' && cc == 'q' && !_dcsIsSixel) {
-      FILE* lg = sixel_log();
-      if (lg) { fprintf(lg, "[sixel] saw 'q' final; tokenBufPos=%d\n", tokenBufferPos); fflush(lg); }
   }
 
   // Sixel DCS fast path: once a DCS sequence has been recognised as sixel
@@ -603,15 +578,6 @@ void Vt102Emulation::processWindowAttributeChange()
                                 "\033]11;rgb:%04x/%04x/%04x\033\\",
                                 r16, g16, b16);
     if (n > 0) sendString(buf, n);
-    {
-      FILE* lg = sixel_log();
-      if (lg) {
-        fprintf(lg, "[osc11] reply bg=#%02x%02x%02x\n",
-                _backgroundColor.red(), _backgroundColor.green(),
-                _backgroundColor.blue());
-        fflush(lg);
-      }
-    }
     return;
   }
 
@@ -624,64 +590,19 @@ void Vt102Emulation::processWindowAttributeChange()
   _titleUpdateTimer->start(20);
 }
 
-static FILE* sixel_log() {
-    static FILE* f = fopen("/tmp/sixel-debug.log", "a");
-    if (f) {
-        static bool wroteHeader = false;
-        if (!wroteHeader) {
-            wroteHeader = true;
-            fprintf(f, "----- sixel log session start -----\n");
-            fflush(f);
-        }
-    }
-    return f;
-}
-
 void Vt102Emulation::processSixelDcs()
 {
-  FILE* lg = sixel_log();
-  if (lg) {
-    fprintf(lg, "[sixel] DCS payload bytes=%lld first32=%s\n",
-            static_cast<long long>(_dcsPayload.size()),
-            _dcsPayload.left(32).toHex().constData());
-    fflush(lg);
-  }
-
-  // Dump payload to a file for offline inspection with sixel2png.
-  {
-    FILE* d = fopen("/tmp/sixel-payload.bin", "wb");
-    if (d) {
-      // Reconstruct the canonical DCS envelope so sixel2png can consume it.
-      fputs("\033Pq", d);
-      fwrite(_dcsPayload.constData(), 1, _dcsPayload.size(), d);
-      fputs("\033\\", d);
-      fclose(d);
-    }
-  }
   QImage image = SixelDecoder::decode(_dcsPayload, _dcsSixelTransparent);
   if (image.isNull())
-  {
-    if (lg) { fprintf(lg, "[sixel] decode returned null image\n"); fflush(lg); }
     return;
-  }
 
   const int cellW = _cellPixelWidth;
   const int cellH = _cellPixelHeight;
   if (cellW <= 0 || cellH <= 0)
-  {
-    if (lg) { fprintf(lg, "[sixel] no cell metrics w=%d h=%d\n", cellW, cellH); fflush(lg); }
     return;
-  }
 
   const int cellRows = (image.height() + cellH - 1) / cellH;
   const int cellCols = (image.width()  + cellW - 1) / cellW;
-  if (lg) {
-    fprintf(lg, "[sixel] decoded %dx%d cellRows=%d cellCols=%d cuY=%d cuX=%d hist=%d\n",
-            image.width(), image.height(), cellRows, cellCols,
-            _currentScreen->getCursorY(), _currentScreen->getCursorX(),
-            _currentScreen->getHistLines());
-    fflush(lg);
-  }
 
   // Anchor at the current cursor position BEFORE advancing. The anchor is
   // stored in ScreenWindow line space (0 = oldest history line); subsequent

--- a/lib/Vt102Emulation.h
+++ b/lib/Vt102Emulation.h
@@ -27,8 +27,9 @@
 #include <cstdio>
 
 // Qt
-#include <QKeyEvent>
+#include <QByteArray>
 #include <QHash>
+#include <QKeyEvent>
 #include <QTimer>
 
 // Konsole
@@ -199,6 +200,19 @@ private:
   bool _reportFocusEvents;
 
   QStringEncoder _toUtf8;
+
+  // DCS payload accumulation for sixel (DCS ... q <sixel> ST).
+  //
+  // The fixed-size tokenBuffer is too small for sixel images (10s of KB+),
+  // so once we recognize a sixel DCS (final char 'q' after DCS params), we
+  // start appending raw bytes here instead of growing tokenBuffer.
+  QByteArray _dcsPayload;
+  bool       _dcsIsSixel;
+  bool       _dcsSixelTransparent;
+
+  // Dispatch the accumulated sixel payload to the decoder and screen.
+  // Called from the Cte branch when the ST terminator arrives.
+  void processSixelDcs();
 };
 
 }


### PR DESCRIPTION
Introduces optional dependency on libsixel. CMakeLists.txt has new QTERMWIDGET_USE_SIXEL option, pkg-config detects libsixel, defines QTERMWIDGET-SIXEL and links the lib.