### PR TITLE
Commented out some debug messages

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -107,12 +107,12 @@ const QChar LTR_OVERRIDE_CHAR( 0x202D );
 
 inline int TerminalDisplay::loc(int x, int y) const
 {
-    if (y < 0 || y >= _lines) {
-        qWarning() << "loc(): Y:" << y << ", Lines:" << _lines;
-    }
-    if (x < 0 || x >= _columns) {
-        qWarning() << "loc(): X:" << x << ", Columns:" << _columns;
-    }
+    // if (y < 0 || y >= _lines) {
+    //     qWarning() << "loc(): Y:" << y << ", Lines:" << _lines;
+    // }
+    // if (x < 0 || x >= _columns) {
+    //     qWarning() << "loc(): X:" << x << ", Columns:" << _columns;
+    // }
 
     // Q_ASSERT(y >= 0 && y < _lines);
     // Q_ASSERT(x >= 0 && x < _columns);


### PR DESCRIPTION
They are annoying for users, and devs know how to enable them. For example, something like the following message was constantly produced on putting the mouse cursor over the scroll-bar or just tiling (e.g., under labwc):

```
loc(): X: 80 , Columns: 80
```

Please do not revert this again after it's merged.

→ https://github.com/lxqt/qtermwidget/pull/642#issuecomment-4683634740

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

