### PR TITLE
vt102emulation: Implement OSC-52 (clipboard) handling

### DIFF
--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -32,6 +32,8 @@
 #include <QEvent>
 #include <QKeyEvent>
 #include <QDebug>
+#include <QApplication>
+#include <QClipboard>
 
 // Konsole
 #include "KeyboardTranslator.h"
@@ -460,6 +462,35 @@ void Vt102Emulation::processWindowAttributeChange()
   // 0x07 or 0x92. Note that as control characters in OSC text parts are
   // ignored, only the second char in ST ("\e\\") is appended to tokenBuffer.
   QString newValue = QString::fromWCharArray(&tokenBuffer[i + 1], tokenBufferPos-i-2);
+
+  // Handle OSC 52 - Clipboard operations (copy/clear clipboard content)
+  // OSC 52 ; Pc ; Pd ST
+  // - Pc 'p' - primary, 'c' - clipboard, 's' - cut buffers
+  // - Pd base64-encoded content
+  // - ST string terminator (already dismissed from new newValue)
+  // (if no Pd, i.e. only one part of ;-delmited list, clear the clipboard/selection)
+  if (attributeToChange == 52) {
+    // Parse the clipboard parameters
+    QStringList params = newValue.split(QLatin1Char{';'});
+
+    const bool clipboard = params[0].isEmpty() || params[0].contains(QLatin1Char{'c'}) || params[0].contains(QLatin1Char{'s'});
+    const bool selection = params[0].contains(QLatin1Char{'p'});
+
+    if (params.length() == 2) {
+      // Copy to clipboard
+      if (clipboard)
+        QApplication::clipboard()->setText(QString::fromUtf8(QByteArray::fromBase64(params[1].toUtf8())), QClipboard::Clipboard);
+      if (selection)
+        QApplication::clipboard()->setText(QString::fromUtf8(QByteArray::fromBase64(params[1].toUtf8())), QClipboard::Selection);
+    } else {
+      // Clear clipboard
+      if (clipboard)
+        QApplication::clipboard()->setText(QString{}, QClipboard::Clipboard);
+      if (selection)
+        QApplication::clipboard()->setText(QString{}, QClipboard::Selection);
+    }
+    return;
+  }
 
   _pendingTitleUpdates[attributeToChange] = newValue;
   _titleUpdateTimer->start(20);

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -42,6 +42,7 @@ using namespace Konsole;
 
 Vt102Emulation::Vt102Emulation()
     : Emulation(),
+     tokenBuffer(256),
      prevCC(0),
      _titleUpdateTimer(new QTimer(this)),
      _reportFocusEvents(false),
@@ -189,7 +190,12 @@ void Vt102Emulation::addArgument()
 void Vt102Emulation::addToCurrentToken(wchar_t cc)
 {
   tokenBuffer[tokenBufferPos] = cc;
-  tokenBufferPos = qMin(tokenBufferPos+1,MAX_TOKEN_LENGTH-1);
+  if (++tokenBufferPos >= tokenBuffer.size()) {
+    if (tokenBuffer.size() < MAX_TOKEN_LENGTH)
+      tokenBuffer.resize(std::min(tokenBuffer.size() * 2, MAX_TOKEN_LENGTH));
+    else
+      --tokenBufferPos;
+  }
 }
 
 // Character Class flags used while decoding
@@ -302,7 +308,7 @@ void Vt102Emulation::receiveChar(wchar_t cc)
   // advance the state
   addToCurrentToken(cc);
 
-  wchar_t* s = tokenBuffer;
+  wchar_t* s = &tokenBuffer[0];
   int  p = tokenBufferPos;
 
   if (getMode(MODE_Ansi))
@@ -436,7 +442,7 @@ void Vt102Emulation::processWindowAttributeChange()
   // Describes the window or terminal session attribute to change
   // See Session::UserTitleChange for possible values
   int attributeToChange = 0;
-  int i;
+  std::size_t i;
   for (i = 2; i < tokenBufferPos     &&
               tokenBuffer[i] >= '0'  &&
               tokenBuffer[i] <= '9'; i++)
@@ -453,7 +459,7 @@ void Vt102Emulation::processWindowAttributeChange()
   // copy from the first char after ';', and skipping the ending delimiter
   // 0x07 or 0x92. Note that as control characters in OSC text parts are
   // ignored, only the second char in ST ("\e\\") is appended to tokenBuffer.
-  QString newValue = QString::fromWCharArray(tokenBuffer + i + 1, tokenBufferPos-i-2);
+  QString newValue = QString::fromWCharArray(&tokenBuffer[i + 1], tokenBufferPos-i-2);
 
   _pendingTitleUpdates[attributeToChange] = newValue;
   _titleUpdateTimer->start(20);
@@ -1474,7 +1480,7 @@ void Vt102Emulation::reportDecodingError()
 {
   if (tokenBufferPos == 0 || ( tokenBufferPos == 1 && (tokenBuffer[0] & 0xff) >= 32) )
     return;
-  qCDebug(qtermwidgetLogger) << "Undecodable sequence:" << QString::fromWCharArray(tokenBuffer, tokenBufferPos);
+  qCDebug(qtermwidgetLogger) << "Undecodable sequence:" << QString::fromWCharArray(&tokenBuffer[0], tokenBufferPos);
 }
 
 //#include "Vt102Emulation.moc"

--- a/lib/Vt102Emulation.h
+++ b/lib/Vt102Emulation.h
@@ -133,10 +133,10 @@ private:
   void resetModes();
 
   void resetTokenizer();
-  #define MAX_TOKEN_LENGTH 256 // Max length of tokens (e.g. window title)
+  static constexpr std::size_t MAX_TOKEN_LENGTH = 50 * (0x1 << 20); // Max length of tokens (e.g. window title, clipboard)
   void addToCurrentToken(wchar_t cc);
-  wchar_t tokenBuffer[MAX_TOKEN_LENGTH]; //FIXME: overflow?
-  int tokenBufferPos;
+  std::vector<wchar_t> tokenBuffer;
+  std::size_t tokenBufferPos;
 #define MAXARGS 15
   void addDigit(int dig);
   void addArgument();


### PR DESCRIPTION
The format is: 
OSC 52 ; Pc ; Pd ST
- OSC is the byte 0x1B followed by ] (i.e., \033]).
- Pc specifies the clipboard buffer to target. Common options include c (standard clipboard) or p (primary clipboard / X11 selection).
- Pd is text encoded in Base64.
- ST is the string terminator, typically the bell character \a or the string terminator \033\ (i.e., \E\).

Inspired by konsole's implementation -> https://invent.kde.org/utilities/konsole/-/commit/9f7a2b846afbf3d34d10c224a9f3b32ce7aa1379


Note: we needed to increase the internal processing buffer and I'm not sure if it can broke binary compatibility (it worked on my machine even w/o recompiling qterminal)
@tsujan @luis-pereira ?