### PR TITLE
fix: connect focus signals for DECSET 1004 focus reporting

### DIFF
--- a/lib/Session.cpp
+++ b/lib/Session.cpp
@@ -202,6 +202,13 @@ void Session::addView(TerminalDisplay * widget)
         connect( widget , SIGNAL(sendStringToEmu(const char *)) , _emulation ,
                  SLOT(sendString(const char *)) );
 
+        // connect focus events for DECSET 1004 focus reporting
+        // (sends \033[I on focus gain, \033[O on focus loss)
+        connect( widget , SIGNAL(termGetFocus()) , _emulation ,
+                 SLOT(focusGained()) );
+        connect( widget , SIGNAL(termLostFocus()) , _emulation ,
+                 SLOT(focusLost()) );
+
         // allow emulation to notify view when the foreground process
         // indicates whether or not it is interested in mouse signals
         connect( _emulation , SIGNAL(programUsesMouseChanged(bool)) , widget ,


### PR DESCRIPTION
The DECSET 1004 (Focus Events) mode was non-functional because TerminalDisplay::termGetFocus() and termLostFocus() signals were never connected to Vt102Emulation::focusGained() and focusLost() slots. This meant that even when a terminal application enabled focus reporting via CSI ? 1004 h, the xterm-compatible escape sequences \033[I (focus gained) and \033[O (focus lost) were never sent back to the application.

Fix: add the missing signal/slot connections in Session::addView() alongside the existing keyboard and mouse signal connections.

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

