### PR TITLE
Add Fill background image mode

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -1514,6 +1514,24 @@ void TerminalDisplay::paintEvent( QPaintEvent* pe )
         r.moveCenter(cr.center());
         paint.drawPixmap(r.topLeft(), _backgroundImage);
     }
+    else if (_backgroundMode == Fill)
+    { // zoom in/out the image to fill all empty space
+        QRect r = _backgroundImage.rect();
+        qreal wRatio = static_cast<qreal>(cr.width()) / r.width();
+        qreal hRatio = static_cast<qreal>(cr.height()) / r.height();
+        if (wRatio < hRatio)
+        {
+            r.setWidth(qRound(r.width() * hRatio));
+            r.setHeight(cr.height());
+        }
+        else
+        {
+            r.setHeight(qRound(r.height() * wRatio));
+            r.setWidth(cr.width());
+        }
+        r.moveCenter(cr.center());
+        paint.drawPixmap(r, _backgroundImage, _backgroundImage.rect());
+    }
     else //if (_backgroundMode == None)
     {
         paint.drawPixmap(0, 0, _backgroundImage);

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -67,7 +67,8 @@ namespace Konsole
         Stretch,
         Zoom,
         Fit,
-        Center
+        Center,
+        Fill
     };
 
 extern unsigned short vt100_graphics[32];


### PR DESCRIPTION
Adds a background image mode that fills all the empty space without distorting the image.  A common mode, but it was missing here.

See also my related PR in qterminal to add UI support for choosing this new mode. ( https://github.com/lxqt/qterminal/pull/1341 )

Combined, they address qterminal issue 1326. ( https://github.com/lxqt/qterminal/issues/1326 )