### PR TITLE
Add QTermWidget::sendByteArray signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ void | finished()
 void | profileChanged(const QString &_profile_)
 void | receivedData(const QString &_text_)
 void | sendData(const char*, int)
+void | sendByteArray(const QByteArray&)
 void | silence()
 void | termGetFocus()
 void | termKeyPressed(QKeyEvent*)
@@ -271,6 +272,9 @@ Wrapped, scroll to end of text.
 
 __void sendData(const char*, int)__\
 Emitted when emulator send data to the terminal process (redirected for external recipient). It can be used for control and display the remote terminal.
+
+__void sendByteArray(const QByteArray&)__\
+The same as sendData, but has QByteArray parameter.
 
 __void sendText(QString &_text_)__\
 Send text to terminal.

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -285,8 +285,12 @@ void QTermWidget::startTerminalTeletype()
 
     m_impl->m_session->runEmptyPTY();
     // redirect data from TTY to external recipient
-    connect( m_impl->m_session->emulation(), SIGNAL(sendData(const char *,int)),
-             this, SIGNAL(sendData(const char *,int)) );
+    connect( m_impl->m_session->emulation(), &Emulation::sendData,
+             [this](const char * data, int lenght) {
+                emit sendData(data, lenght);
+                emit sendByteArray(QByteArray::fromRawData(data,lenght));
+             }
+            );
 }
 
 void QTermWidget::init(int startnow)

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -288,6 +288,7 @@ signals:
      * control and display the remote terminal.
      */
     void sendData(const char *,int);
+    void sendByteArray(const QByteArray&);
 
     void profileChanged(const QString & profile);
 


### PR DESCRIPTION
This signal is emmited the same way as QTermWidget::sendData, but pass data in QByteArray(sendData pass (const char*, int)). This signal is needed when we use this widget in PySide6 applications. In this application we can't connect sendData in python code because shiboken6 doesn't convert const char *, int in python data.

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

