### PR TITLE
Add OSC-8 hyperlink support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(SRCS
     lib/Filter.cpp
     lib/History.cpp
     lib/HistorySearch.cpp
+    lib/Hyperlink.cpp
     lib/KeyboardTranslator.cpp
     lib/konsole_wcwidth.cpp
     lib/kprocess.cpp

--- a/lib/Character.h
+++ b/lib/Character.h
@@ -75,8 +75,9 @@ public:
   inline Character(quint16 _c = ' ',
             CharacterColor  _f = CharacterColor(COLOR_SPACE_DEFAULT,DEFAULT_FORE_COLOR),
             CharacterColor  _b = CharacterColor(COLOR_SPACE_DEFAULT,DEFAULT_BACK_COLOR),
-            quint8  _r = DEFAULT_RENDITION)
-       : character(_c), rendition(_r), foregroundColor(_f), backgroundColor(_b) {}
+            quint8  _r = DEFAULT_RENDITION,
+            quint16 _hyperlinkId = 0)
+       : character(_c), rendition(_r), foregroundColor(_f), backgroundColor(_b), hyperlinkId(_hyperlinkId) {}
 
   /** The unicode character value for this character.
    *
@@ -92,6 +93,12 @@ public:
   CharacterColor  foregroundColor;
   /** The color used to draw this character's background. */
   CharacterColor  backgroundColor;
+
+  /**
+   * OSC-8 hyperlink id for this cell (0 = none).
+   * Look up the URI with HyperlinkTable::instance.href(hyperlinkId).
+   */
+  quint16 hyperlinkId;
 
   /**
    * Returns true if this character has a transparent background when
@@ -137,7 +144,8 @@ inline bool operator == (const Character& a, const Character& b)
   return a.character == b.character &&
          a.rendition == b.rendition &&
          a.foregroundColor == b.foregroundColor &&
-         a.backgroundColor == b.backgroundColor;
+         a.backgroundColor == b.backgroundColor &&
+         a.hyperlinkId == b.hyperlinkId;
 }
 
 inline bool operator != (const Character& a, const Character& b)
@@ -145,7 +153,8 @@ inline bool operator != (const Character& a, const Character& b)
   return    a.character != b.character ||
             a.rendition != b.rendition ||
             a.foregroundColor != b.foregroundColor ||
-            a.backgroundColor != b.backgroundColor;
+            a.backgroundColor != b.backgroundColor ||
+            a.hyperlinkId != b.hyperlinkId;
 }
 
 inline bool Character::isTransparent(const ColorEntry* base) const
@@ -161,7 +170,8 @@ inline bool Character::equalsFormat(const Character& other) const
   return
     backgroundColor==other.backgroundColor &&
     foregroundColor==other.foregroundColor &&
-    rendition==other.rendition;
+    rendition==other.rendition &&
+    hyperlinkId==other.hyperlinkId;
 }
 
 inline ColorEntry::FontWeight Character::fontWeight(const ColorEntry* base) const

--- a/lib/Filter.cpp
+++ b/lib/Filter.cpp
@@ -701,7 +701,8 @@ void HyperlinkFilter::process()
                 ++col;
 
             int endLine = line;
-            int endCol = col - 1;
+            // Exclusive end column (one past the last linked cell), same convention as UrlFilter.
+            int endCol = col;
 
             // Merge with following wrapped lines that continue the same link id
             int mergeLine = line;
@@ -713,11 +714,11 @@ void HyperlinkFilter::process()
                 while (c < _columns && _image[mergeLine * _columns + c].hyperlinkId == id)
                     ++c;
                 endLine = mergeLine;
-                endCol = c - 1;
+                endCol = c;
             }
 
             const QString href = HyperlinkTable::instance.href(id);
-            if (!href.isEmpty() && endCol >= startCol) {
+            if (!href.isEmpty() && endCol > startCol) {
                 auto* spot = new HotSpot(startLine, startCol, endLine, endCol, href);
                 connect(spot->getUrlObject(), &FilterObject::activated,
                         this, &HyperlinkFilter::activated);
@@ -727,7 +728,7 @@ void HyperlinkFilter::process()
             if (endLine > line) {
                 // Skip the merged lines; continue scanning after the run on the last line
                 line = endLine;
-                col = endCol + 1;
+                col = endCol;
             }
         }
         ++line;

--- a/lib/Filter.cpp
+++ b/lib/Filter.cpp
@@ -35,13 +35,17 @@
 #include <QDesktopServices>
 #include <QUrl>
 
+#include <utility>
+
 // KDE
 //#include <KLocale>
 //#include <KRun>
 
 // Konsole
+#include "Character.h"
 #include "TerminalCharacterDecoder.h"
 #include "konsole_wcwidth.h"
+#include "Hyperlink.h"
 
 using namespace Konsole;
 
@@ -73,6 +77,17 @@ RegExpFilter* FilterChain::getRegExpFilter(const QString& name) const
                 }
             }
         }
+    }
+    return nullptr;
+}
+
+HyperlinkFilter* FilterChain::getHyperlinkFilter() const
+{
+    QListIterator<Filter*> iter(*this);
+    while (iter.hasNext())
+    {
+        if (auto* f = qobject_cast<HyperlinkFilter*>(iter.next()))
+            return f;
     }
     return nullptr;
 }
@@ -159,6 +174,14 @@ void TerminalImageFilterChain::setImage(const Character* const image , int lines
 
     // reset all filters and hotspots
     reset();
+
+    // Give OSC-8 hyperlink filters access to the Character image
+    QListIterator<Filter*> filterIter(*this);
+    while (filterIter.hasNext()) {
+        if (auto* hyperlinkFilter = qobject_cast<HyperlinkFilter*>(filterIter.next())) {
+            hyperlinkFilter->setImage(image, lines, columns, lineProperties);
+        }
+    }
 
     PlainTextDecoder decoder;
     // Include trailing whitespace because otherwise, if a string is wrapped at
@@ -318,6 +341,10 @@ Filter::HotSpot::HotSpot(int startLine , int startColumn , int endLine , int end
 QList<QAction*> Filter::HotSpot::actions()
 {
     return QList<QAction*>();
+}
+QString Filter::HotSpot::tooltip() const
+{
+    return QString();
 }
 int Filter::HotSpot::startLine() const
 {
@@ -572,6 +599,11 @@ UrlFilter::HotSpot::~HotSpot()
     delete _urlObject;
 }
 
+QString UrlFilter::HotSpot::tooltip() const
+{
+    return capturedTexts().value(0);
+}
+
 void FilterObject::emitActivated(const QUrl& url, bool fromContextMenu)
 {
     emit activated(url, fromContextMenu);
@@ -621,6 +653,150 @@ QList<QAction*> UrlFilter::HotSpot::actions()
     list << openAction;
     list << copyAction;
 
+    return list;
+}
+
+// ==================== HyperlinkFilter (OSC-8) ====================
+
+HyperlinkFilter::HyperlinkFilter() = default;
+
+HyperlinkFilter::~HyperlinkFilter() = default;
+
+void HyperlinkFilter::setEnabled(bool enabled)
+{
+    _enabled = enabled;
+}
+
+bool HyperlinkFilter::isEnabled() const
+{
+    return _enabled;
+}
+
+void HyperlinkFilter::setImage(const Character* image, int lines, int columns,
+                               const QVector<LineProperty>& lineProperties)
+{
+    _image = image;
+    _lines = lines;
+    _columns = columns;
+    _lineProperties = lineProperties;
+}
+
+void HyperlinkFilter::process()
+{
+    if (!_enabled || !_image || _lines <= 0 || _columns <= 0)
+        return;
+
+    for (int line = 0; line < _lines; ) {
+        int col = 0;
+        while (col < _columns) {
+            const quint16 id = _image[line * _columns + col].hyperlinkId;
+            if (id == 0) {
+                ++col;
+                continue;
+            }
+
+            const int startLine = line;
+            const int startCol = col;
+            while (col < _columns && _image[line * _columns + col].hyperlinkId == id)
+                ++col;
+
+            int endLine = line;
+            int endCol = col - 1;
+
+            // Merge with following wrapped lines that continue the same link id
+            int mergeLine = line;
+            while (mergeLine + 1 < _lines
+                   && (_lineProperties.value(mergeLine, LINE_DEFAULT) & LINE_WRAPPED)
+                   && _image[(mergeLine + 1) * _columns].hyperlinkId == id) {
+                ++mergeLine;
+                int c = 0;
+                while (c < _columns && _image[mergeLine * _columns + c].hyperlinkId == id)
+                    ++c;
+                endLine = mergeLine;
+                endCol = c - 1;
+            }
+
+            const QString href = HyperlinkTable::instance.href(id);
+            if (!href.isEmpty() && endCol >= startCol) {
+                auto* spot = new HotSpot(startLine, startCol, endLine, endCol, href);
+                connect(spot->getUrlObject(), &FilterObject::activated,
+                        this, &HyperlinkFilter::activated);
+                addHotSpot(spot);
+            }
+
+            if (endLine > line) {
+                // Skip the merged lines; continue scanning after the run on the last line
+                line = endLine;
+                col = endCol + 1;
+            }
+        }
+        ++line;
+    }
+
+    _image = nullptr;
+}
+
+HyperlinkFilter::HotSpot::HotSpot(int startLine, int startColumn, int endLine, int endColumn,
+                                  const QString& url)
+    : Filter::HotSpot(startLine, startColumn, endLine, endColumn)
+    , _urlObject(new FilterObject(this))
+    , _url(url)
+{
+    setType(Link);
+}
+
+HyperlinkFilter::HotSpot::~HotSpot()
+{
+    delete _urlObject;
+}
+
+FilterObject* HyperlinkFilter::HotSpot::getUrlObject() const
+{
+    return _urlObject;
+}
+
+QString HyperlinkFilter::HotSpot::url() const
+{
+    return _url;
+}
+
+QString HyperlinkFilter::HotSpot::tooltip() const
+{
+    return _url;
+}
+
+void HyperlinkFilter::HotSpot::activate(const QString& actionName)
+{
+    if (actionName == QLatin1String("copy-action")) {
+        QApplication::clipboard()->setText(_url);
+        return;
+    }
+
+    if (actionName.isEmpty()
+        || actionName == QLatin1String("open-action")
+        || actionName == QLatin1String("click-action")) {
+        _urlObject->emitActivated(QUrl(_url, QUrl::StrictMode),
+                                  actionName != QLatin1String("click-action"));
+    }
+}
+
+QList<QAction*> HyperlinkFilter::HotSpot::actions()
+{
+    QList<QAction*> list;
+
+    QAction* openAction = new QAction(_urlObject);
+    QAction* copyAction = new QAction(_urlObject);
+
+    openAction->setText(QObject::tr("Open Link"));
+    copyAction->setText(QObject::tr("Copy Link Address"));
+    openAction->setObjectName(QLatin1String("open-action"));
+    copyAction->setObjectName(QLatin1String("copy-action"));
+
+    QObject::connect(openAction, &QAction::triggered, _urlObject, &FilterObject::activate);
+    QObject::connect(copyAction, &QAction::triggered, _urlObject, &FilterObject::activate);
+
+    list << openAction;
+    list << copyAction;
     return list;
 }
 

--- a/lib/Filter.cpp
+++ b/lib/Filter.cpp
@@ -660,7 +660,12 @@ QList<QAction*> UrlFilter::HotSpot::actions()
 
 HyperlinkFilter::HyperlinkFilter() = default;
 
-HyperlinkFilter::~HyperlinkFilter() = default;
+HyperlinkFilter::~HyperlinkFilter()
+{
+    clear(); // base d-tor must not delete hotspots still owned via _oldHotspotList
+    qDeleteAll(_oldHotspotList);
+    _oldHotspotList.clear();
+}
 
 void HyperlinkFilter::setEnabled(bool enabled)
 {
@@ -681,57 +686,93 @@ void HyperlinkFilter::setImage(const Character* image, int lines, int columns,
     _lineProperties = lineProperties;
 }
 
+void HyperlinkFilter::reset()
+{
+    // Clear hotspots without deleting them; otherwise Open/Copy actions parented to the
+    // hotspot's FilterObject are destroyed on every refresh.
+    clear();
+}
+
+void HyperlinkFilter::addOrReuseHotSpot(int startLine, int startColumn, int endLine, int endColumn,
+                                        const QString& url)
+{
+    for (HotSpot* hs : std::as_const(_oldHotspotList)) {
+        if (hs->startLine() == startLine &&
+            hs->endLine() == endLine &&
+            hs->startColumn() == startColumn &&
+            hs->endColumn() == endColumn) {
+            hs->setUrl(url);
+            addHotSpot(hs);
+            return;
+        }
+    }
+
+    auto* spot = new HotSpot(startLine, startColumn, endLine, endColumn, url);
+    connect(spot->getUrlObject(), &FilterObject::activated,
+            this, &HyperlinkFilter::activated);
+    addHotSpot(spot);
+}
+
 void HyperlinkFilter::process()
 {
-    if (!_enabled || !_image || _lines <= 0 || _columns <= 0)
-        return;
+    if (_enabled && _image && _lines > 0 && _columns > 0) {
+        for (int line = 0; line < _lines; ) {
+            int col = 0;
+            while (col < _columns) {
+                const quint16 id = _image[line * _columns + col].hyperlinkId;
+                if (id == 0) {
+                    ++col;
+                    continue;
+                }
 
-    for (int line = 0; line < _lines; ) {
-        int col = 0;
-        while (col < _columns) {
-            const quint16 id = _image[line * _columns + col].hyperlinkId;
-            if (id == 0) {
-                ++col;
-                continue;
+                const int startLine = line;
+                const int startCol = col;
+                while (col < _columns && _image[line * _columns + col].hyperlinkId == id)
+                    ++col;
+
+                int endLine = line;
+                // Exclusive end column (one past the last linked cell), same convention as UrlFilter.
+                int endCol = col;
+
+                // Merge with following wrapped lines that continue the same link id
+                int mergeLine = line;
+                while (mergeLine + 1 < _lines
+                       && (_lineProperties.value(mergeLine, LINE_DEFAULT) & LINE_WRAPPED)
+                       && _image[(mergeLine + 1) * _columns].hyperlinkId == id) {
+                    ++mergeLine;
+                    int c = 0;
+                    while (c < _columns && _image[mergeLine * _columns + c].hyperlinkId == id)
+                        ++c;
+                    endLine = mergeLine;
+                    endCol = c;
+                }
+
+                const QString href = HyperlinkTable::instance.href(id);
+                if (!href.isEmpty() && endCol > startCol)
+                    addOrReuseHotSpot(startLine, startCol, endLine, endCol, href);
+
+                if (endLine > line) {
+                    // Skip the merged lines; continue scanning after the run on the last line
+                    line = endLine;
+                    col = endCol;
+                }
             }
-
-            const int startLine = line;
-            const int startCol = col;
-            while (col < _columns && _image[line * _columns + col].hyperlinkId == id)
-                ++col;
-
-            int endLine = line;
-            // Exclusive end column (one past the last linked cell), same convention as UrlFilter.
-            int endCol = col;
-
-            // Merge with following wrapped lines that continue the same link id
-            int mergeLine = line;
-            while (mergeLine + 1 < _lines
-                   && (_lineProperties.value(mergeLine, LINE_DEFAULT) & LINE_WRAPPED)
-                   && _image[(mergeLine + 1) * _columns].hyperlinkId == id) {
-                ++mergeLine;
-                int c = 0;
-                while (c < _columns && _image[mergeLine * _columns + c].hyperlinkId == id)
-                    ++c;
-                endLine = mergeLine;
-                endCol = c;
-            }
-
-            const QString href = HyperlinkTable::instance.href(id);
-            if (!href.isEmpty() && endCol > startCol) {
-                auto* spot = new HotSpot(startLine, startCol, endLine, endCol, href);
-                connect(spot->getUrlObject(), &FilterObject::activated,
-                        this, &HyperlinkFilter::activated);
-                addHotSpot(spot);
-            }
-
-            if (endLine > line) {
-                // Skip the merged lines; continue scanning after the run on the last line
-                line = endLine;
-                col = endCol;
-            }
+            ++line;
         }
-        ++line;
+    }
+
+    // Delete invalid old hotspots if any; keep still-valid ones (and their actions).
+    const auto hotspotList = hotSpots();
+    for (Filter::HotSpot* hs : hotspotList) {
+        if (auto* linkHs = dynamic_cast<HotSpot*>(hs))
+            _oldHotspotList.removeAll(linkHs);
+    }
+    qDeleteAll(_oldHotspotList);
+    _oldHotspotList.clear();
+
+    for (Filter::HotSpot* hs : hotspotList) {
+        if (auto* linkHs = dynamic_cast<HotSpot*>(hs))
+            _oldHotspotList << linkHs;
     }
 
     _image = nullptr;
@@ -759,6 +800,11 @@ FilterObject* HyperlinkFilter::HotSpot::getUrlObject() const
 QString HyperlinkFilter::HotSpot::url() const
 {
     return _url;
+}
+
+void HyperlinkFilter::HotSpot::setUrl(const QString& url)
+{
+    _url = url;
 }
 
 QString HyperlinkFilter::HotSpot::tooltip() const

--- a/lib/Filter.h
+++ b/lib/Filter.h
@@ -335,6 +335,7 @@ public:
 
         FilterObject* getUrlObject() const;
         QString url() const;
+        void setUrl(const QString& url);
 
         QList<QAction*> actions() override;
         void activate(const QString& action = QString()) override;
@@ -363,16 +364,23 @@ public:
                   const QVector<LineProperty>& lineProperties);
 
     void process() override;
+    void reset() override;
 
 signals:
     void activated(const QUrl& url, bool fromContextMenu);
 
 private:
+    void addOrReuseHotSpot(int startLine, int startColumn, int endLine, int endColumn,
+                           const QString& url);
+
     const Character* _image = nullptr;
     int _lines = 0;
     int _columns = 0;
     QVector<LineProperty> _lineProperties;
     bool _enabled = true;
+    // Kept across reset()/process() so Open/Copy actions are not destroyed on refresh
+    // (same approach as UrlFilter).
+    QList<HotSpot*> _oldHotspotList;
 };
 
 class QTERMWIDGET_NO_EXPORT FilterObject : public QObject

--- a/lib/Filter.h
+++ b/lib/Filter.h
@@ -26,6 +26,8 @@
 #include <QStringList>
 #include <QHash>
 #include <QRegularExpression>
+#include <QVector>
+#include <QUrl>
 
 // Local
 #include "qtermwidget_export.h"
@@ -102,6 +104,12 @@ public:
         * the hotspot graphically.  eg.  Link hotspots are typically underlined when the user mouses over them
         */
        Type type() const;
+       /**
+        * Returns a tooltip string for this hotspot, or empty if none.
+        * Used e.g. to show the destination URL when hovering a link.
+        */
+       virtual QString tooltip() const;
+
        /**
         * Causes the an action associated with a hotspot to be triggered.
         *
@@ -264,6 +272,8 @@ public:
 
         QList<QAction*> actions() override;
 
+        QString tooltip() const override;
+
         /**
          * Open a web browser at the current URL.  The url itself can be determined using
          * the capturedTexts() method.
@@ -306,6 +316,63 @@ private:
     QList<UrlFilter::HotSpot*> _oldHotspotList;
 signals:
     void activated(const QUrl& url, bool fromContextMenu);
+};
+
+/**
+ * A filter which finds OSC-8 hyperlinks by scanning Character cells for
+ * non-zero hyperlinkId values and creates Link hotspots for them.
+ */
+class QTERMWIDGET_EXPORT HyperlinkFilter : public Filter
+{
+    Q_OBJECT
+public:
+    class HotSpot : public Filter::HotSpot
+    {
+    public:
+        HotSpot(int startLine, int startColumn, int endLine, int endColumn,
+                const QString& url);
+        ~HotSpot() override;
+
+        FilterObject* getUrlObject() const;
+        QString url() const;
+
+        QList<QAction*> actions() override;
+        void activate(const QString& action = QString()) override;
+        QString tooltip() const override;
+
+    private:
+        FilterObject* _urlObject;
+        QString _url;
+
+        HotSpot(const HotSpot&) = delete;
+        HotSpot& operator=(const HotSpot&) = delete;
+    };
+
+    HyperlinkFilter();
+    ~HyperlinkFilter() override;
+
+    /** When false, process() creates no hotspots (OSC-8 parsing still occurs). */
+    void setEnabled(bool enabled);
+    bool isEnabled() const;
+
+    /**
+     * Provides the terminal Character image used by process().
+     * Called from TerminalImageFilterChain::setImage().
+     */
+    void setImage(const Character* image, int lines, int columns,
+                  const QVector<LineProperty>& lineProperties);
+
+    void process() override;
+
+signals:
+    void activated(const QUrl& url, bool fromContextMenu);
+
+private:
+    const Character* _image = nullptr;
+    int _lines = 0;
+    int _columns = 0;
+    QVector<LineProperty> _lineProperties;
+    bool _enabled = true;
 };
 
 class QTERMWIDGET_NO_EXPORT FilterObject : public QObject
@@ -366,6 +433,9 @@ public:
 
     /** Gets the (first named) RegExpFilter that is not a UrlFilter. */
     RegExpFilter* getRegExpFilter(const QString& name = QString()) const;
+
+    /** Returns the first HyperlinkFilter in the chain, or nullptr. */
+    HyperlinkFilter* getHyperlinkFilter() const;
 
     /** Returns the first hotspot which occurs at @p line, @p column or 0 if no hotspot was found */
     Filter::HotSpot* hotSpotAt(int line , int column) const;

--- a/lib/History.cpp
+++ b/lib/History.cpp
@@ -688,6 +688,7 @@ void CompactHistoryLine::getCharacter ( int index, Character &r )
   r.rendition = formatArray[formatPos].rendition;
   r.foregroundColor = formatArray[formatPos].fgColor;
   r.backgroundColor = formatArray[formatPos].bgColor;
+  r.hyperlinkId = formatArray[formatPos].hyperlinkId;
 }
 
 void CompactHistoryLine::getCharacters ( Character* array, int length, int startColumn )

--- a/lib/History.h
+++ b/lib/History.h
@@ -269,21 +269,25 @@ class CharacterFormat
 {
 public:
   bool equalsFormat(const CharacterFormat &other) const {
-    return other.rendition==rendition && other.fgColor==fgColor && other.bgColor==bgColor;
+    return other.rendition==rendition && other.fgColor==fgColor && other.bgColor==bgColor
+           && other.hyperlinkId==hyperlinkId;
   }
 
   bool equalsFormat(const Character &c) const {
-    return c.rendition==rendition && c.foregroundColor==fgColor && c.backgroundColor==bgColor;
+    return c.rendition==rendition && c.foregroundColor==fgColor && c.backgroundColor==bgColor
+           && c.hyperlinkId==hyperlinkId;
   }
 
   void setFormat(const Character& c) {
     rendition=c.rendition;
     fgColor=c.foregroundColor;
     bgColor=c.backgroundColor;
+    hyperlinkId=c.hyperlinkId;
   }
 
   CharacterColor fgColor, bgColor;
   quint16 startPos;
+  quint16 hyperlinkId = 0;
   quint8 rendition;
 };
 

--- a/lib/Hyperlink.cpp
+++ b/lib/Hyperlink.cpp
@@ -1,0 +1,62 @@
+/*
+    Copyright (C) 2026 The LXQt Team
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <https://www.gnu.org/licenses/>.
+*/
+
+#include "Hyperlink.h"
+
+namespace Konsole
+{
+
+HyperlinkTable HyperlinkTable::instance;
+
+quint16 HyperlinkTable::createHyperlink(const QString& idParam, const QString& uri)
+{
+    if (uri.isEmpty())
+        return 0;
+
+    if (!idParam.isEmpty()) {
+        const QString key = idParam + QLatin1Char('\0') + uri;
+        auto it = _keyToId.constFind(key);
+        if (it != _keyToId.constEnd())
+            return it.value();
+
+        // Wrap around if we somehow exhaust the id space; keep 0 as "none".
+        if (_nextId == 0)
+            ++_nextId;
+
+        const quint16 id = _nextId++;
+        _keyToId.insert(key, id);
+        _idToUri.insert(id, uri);
+        return id;
+    }
+
+    if (_nextId == 0)
+        ++_nextId;
+
+    const quint16 id = _nextId++;
+    _idToUri.insert(id, uri);
+    return id;
+}
+
+QString HyperlinkTable::href(quint16 id) const
+{
+    if (id == 0)
+        return QString();
+    return _idToUri.value(id);
+}
+
+}

--- a/lib/Hyperlink.h
+++ b/lib/Hyperlink.h
@@ -1,0 +1,66 @@
+/*
+    Copyright (C) 2026 The LXQt Team
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see
+    <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef HYPERLINK_H
+#define HYPERLINK_H
+
+// Qt
+#include <QHash>
+#include <QString>
+
+namespace Konsole
+{
+
+/**
+ * Maps per-cell hyperlink identifiers to URI strings for OSC-8 support.
+ *
+ * Character cells store a small id; the URI lives in this table so screen and
+ * history buffers stay compact. Id 0 means "no hyperlink".
+ */
+class HyperlinkTable
+{
+public:
+    HyperlinkTable() = default;
+
+    /**
+     * Allocates or reuses an id for the given OSC-8 params and URI.
+     *
+     * @param idParam Optional id= value from OSC-8 params (may be empty)
+     * @param uri The hyperlink target URI
+     * @return Non-zero id, or 0 if @p uri is empty
+     */
+    quint16 createHyperlink(const QString& idParam, const QString& uri);
+
+    /** Returns the URI for @p id, or an empty string if unknown / id is 0. */
+    QString href(quint16 id) const;
+
+    /** Global table shared by all screens (same pattern as ExtendedCharTable). */
+    static HyperlinkTable instance;
+
+private:
+    QHash<quint16, QString> _idToUri;
+    // Key is "idParam\\0uri" when idParam is non-empty, allowing reuse of the
+    // same OSC-8 id across screen updates. Empty idParam always allocates a
+    // fresh id (VTE-style).
+    QHash<QString, quint16> _keyToId;
+    quint16 _nextId = 1;
+};
+
+}
+
+#endif // HYPERLINK_H

--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -33,6 +33,7 @@
 // Qt
 #include <QTextStream>
 #include <QDate>
+#include <QUrl>
 
 // KDE
 //#include <kdebug.h>
@@ -40,6 +41,7 @@
 // Konsole
 #include "konsole_wcwidth.h"
 #include "TerminalCharacterDecoder.h"
+#include "Hyperlink.h"
 
 using namespace Konsole;
 
@@ -73,6 +75,7 @@ Character Screen::defaultChar = Character(' ',
     history(new HistoryScrollNone()),
     cuX(0), cuY(0),
     currentRendition(0),
+    currentHyperlinkId(0),
     _topMargin(0), _bottomMargin(0),
     selBegin(0), selTopLeft(0), selBottomRight(0),
     blockSelectionMode(false),
@@ -584,6 +587,7 @@ void Screen::reset(bool clearScreen)
     _bottomMargin=lines-1;
 
     setDefaultRendition();
+    clearCurrentHyperlink();
     saveCursor();
 
     if ( clearScreen )
@@ -767,6 +771,7 @@ void Screen::displayCharacter(wchar_t c)
                 ch.foregroundColor = effectiveForeground;
                 ch.backgroundColor = effectiveBackground;
                 ch.rendition = effectiveRendition;
+                ch.hyperlinkId = currentHyperlinkId;
 
                 if (getMode(MODE_Insert))
                 {
@@ -832,6 +837,7 @@ notcombine:
     currentChar.foregroundColor = effectiveForeground;
     currentChar.backgroundColor = effectiveBackground;
     currentChar.rendition = effectiveRendition;
+    currentChar.hyperlinkId = currentHyperlinkId;
 
     lastDrawnChar = c;
 
@@ -849,6 +855,7 @@ notcombine:
         ch.foregroundColor = effectiveForeground;
         ch.backgroundColor = effectiveBackground;
         ch.rendition = effectiveRendition;
+        ch.hyperlinkId = currentHyperlinkId;
 
         w--;
     }
@@ -1157,6 +1164,52 @@ void Screen::setDefaultRendition()
     setBackColor(COLOR_SPACE_DEFAULT,DEFAULT_BACK_COLOR);
     currentRendition   = DEFAULT_RENDITION;
     updateEffectiveRendition();
+}
+
+void Screen::clearCurrentHyperlink()
+{
+    currentHyperlinkId = 0;
+}
+
+void Screen::setHyperlinkFromOsc(const QString& params, const QString& uri)
+{
+    if (uri.isEmpty()) {
+        currentHyperlinkId = 0;
+        return;
+    }
+
+    // Reject obviously malformed URIs (e.g. shell quoting bugs that swallow ST and
+    // append the visible label / trailing OSC junk into the URI payload).
+    for (const QChar ch : uri) {
+        if (ch.isSpace() || ch.category() == QChar::Other_Control) {
+            currentHyperlinkId = 0;
+            return;
+        }
+    }
+
+    const QUrl url(uri, QUrl::StrictMode);
+    const QString scheme = url.scheme().toLower();
+    // Restrict to common safe schemes (same idea as Konsole / VTE defaults).
+    const bool allowedScheme = (scheme == QLatin1String("http")
+                                || scheme == QLatin1String("https")
+                                || scheme == QLatin1String("file")
+                                || scheme == QLatin1String("mailto")
+                                || scheme == QLatin1String("ftp"));
+    if (!url.isValid() || !allowedScheme) {
+        currentHyperlinkId = 0;
+        return;
+    }
+
+    QString idParam;
+    const QStringList parts = params.split(QLatin1Char(':'));
+    for (const QString& part : parts) {
+        if (part.startsWith(QLatin1String("id="))) {
+            idParam = part.mid(3);
+            break;
+        }
+    }
+
+    currentHyperlinkId = HyperlinkTable::instance.createHyperlink(idParam, url.toString());
 }
 
 void Screen::setForeColor(int space, int color)

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -561,6 +561,17 @@ public:
       */
     static void fillWithDefaultChar(Character* dest, int count);
 
+    /**
+     * Applies an OSC-8 hyperlink escape sequence to the current pen state.
+     *
+     * @param params OSC-8 parameter string (e.g. "id=foo" or empty)
+     * @param uri Target URI; empty URI clears the current hyperlink
+     */
+    void setHyperlinkFromOsc(const QString& params, const QString& uri);
+
+    /** Clears the current OSC-8 hyperlink pen state without affecting cells. */
+    void clearCurrentHyperlink();
+
     QSet<uint> usedExtendedChars() const
     {
         QSet<uint> result;
@@ -661,6 +672,9 @@ private:
     CharacterColor currentForeground;
     CharacterColor currentBackground;
     quint8 currentRendition;
+
+    // OSC-8 hyperlink currently being written (0 = none)
+    quint16 currentHyperlinkId;
 
     // margins ----------------
     int _topMargin;

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -38,6 +38,7 @@
 #include <QMessageBox>
 #include <QPainter>
 #include <QPixmap>
+#include <QToolTip>
 #include <QRegularExpression>
 #include <QStyle>
 #include <QTimer>
@@ -391,6 +392,10 @@ TerminalDisplay::TerminalDisplay(QWidget *parent)
 ,_filterChain(new TerminalImageFilterChain())
 ,_cursorShape(Emulation::KeyboardCursorShape::BlockCursor)
 ,mMotionAfterPasting(NoMoveScreenWindow)
+,_confirmMultilinePaste(true)
+,_trimPastedTrailingNewlines(false)
+,_linkTooltipsEnabled(true)
+,_linkTooltipTimer(nullptr)
 ,_leftBaseMargin(1)
 ,_topBaseMargin(1)
 ,_drawLineChars(true)
@@ -430,6 +435,10 @@ TerminalDisplay::TerminalDisplay(QWidget *parent)
   connect(_blinkTimer, SIGNAL(timeout()), this, SLOT(blinkEvent()));
   _blinkCursorTimer   = new QTimer(this);
   connect(_blinkCursorTimer, SIGNAL(timeout()), this, SLOT(blinkCursorEvent()));
+
+  _linkTooltipTimer = new QTimer(this);
+  _linkTooltipTimer->setSingleShot(true);
+  connect(_linkTooltipTimer, &QTimer::timeout, this, &TerminalDisplay::showPendingLinkTooltip);
 
   setUsesMouse(true);
   setBracketedPasteMode(false);
@@ -1184,7 +1193,7 @@ void TerminalDisplay::updateImage()
     }
 
     QFontMetrics fm(font());
-    if (!_resizing) // not while _resizing, we're expecting a paintEvent
+    if (!_resizing) { // not while _resizing, we're expecting a paintEvent
     for (x = 0; x < columnsToUpdate; ++x)
     {
       if ((newLine[x].rendition & RE_BLINK) != 0) {
@@ -1251,6 +1260,7 @@ void TerminalDisplay::updateImage()
         x += len - 1;
       }
 
+    }
     }
 
     //both the top and bottom halves of double height _lines must always be redrawn
@@ -1433,6 +1443,7 @@ void TerminalDisplay::leaveEvent(QEvent* event)
     gs_deadSpot = QPoint(-1,-1);
     QApplication::restoreOverrideCursor();
   }
+  clearLinkTooltip();
   QWidget::leaveEvent(event);
 }
 
@@ -2294,12 +2305,41 @@ void TerminalDisplay::mouseMoveEvent(QMouseEvent* ev)
     }
 
     update( _mouseOverHotspotArea | previousHotspotArea );
+
+    if (_linkTooltipsEnabled) {
+        const QString tip = spot->tooltip();
+        const QPoint globalPos = ev->globalPosition().toPoint();
+        if (tip.isEmpty()) {
+            clearLinkTooltip();
+        } else if (tip == _pendingLinkTooltip) {
+            // Still on the same link: keep the pending position up to date.
+            _pendingLinkTooltipPos = globalPos;
+            if (QToolTip::isVisible())
+                QToolTip::showText(globalPos, tip, this);
+        } else {
+            // New link under the cursor: wait before showing (intentional hover).
+            _pendingLinkTooltip = tip;
+            _pendingLinkTooltipPos = globalPos;
+            QToolTip::hideText();
+            // Snappier than the desktop default (~700ms), but still long enough
+            // that fast mouse sweeps over links do not pop a tip.
+            int delay = style()->styleHint(QStyle::SH_ToolTip_WakeUpDelay, nullptr, this);
+            if (delay < 0)
+                delay = 400;
+            else
+                delay = qMin(delay, 400);
+            _linkTooltipTimer->start(delay);
+        }
+    }
   }
   else if ( !_mouseOverHotspotArea.isEmpty() )
   {
         update( _mouseOverHotspotArea );
         // set hotspot area to an invalid rectangle
         _mouseOverHotspotArea = QRegion();
+        clearLinkTooltip();
+  } else {
+        clearLinkTooltip();
   }
 
   // for auto-hiding the cursor, we need mouseTracking
@@ -2577,7 +2617,7 @@ void TerminalDisplay::getCharacterPosition(const QPointF& widgetPoint,int& line,
     if (line >= _usedLines)
         line = _usedLines - 1;
 
-    int x = widgetPoint.x() + _fontWidth / 2 - contentsRect().left() - _leftMargin;
+    int x = widgetPoint.x() + _fontWidth / 2.0 - contentsRect().left() - _leftMargin;
     if ( _fixedFont )
         column = x / _fontWidth;
     else
@@ -2909,7 +2949,7 @@ void TerminalDisplay::wheelEvent( QWheelEvent* ev )
   if ( _mouseMarks )
   {
     bool canScroll = _scrollBar->maximum() > 0;
-      if (canScroll)
+    if (canScroll)
         _scrollBar->event(ev);
     else
     {
@@ -3189,6 +3229,33 @@ void TerminalDisplay::setConfirmMultilinePaste(bool confirmMultilinePaste) {
 
 void TerminalDisplay::setTrimPastedTrailingNewlines(bool trimPastedTrailingNewlines) {
     _trimPastedTrailingNewlines = trimPastedTrailingNewlines;
+}
+
+void TerminalDisplay::setLinkTooltipsEnabled(bool enabled)
+{
+    _linkTooltipsEnabled = enabled;
+    if (!enabled)
+        clearLinkTooltip();
+}
+
+bool TerminalDisplay::linkTooltipsEnabled() const
+{
+    return _linkTooltipsEnabled;
+}
+
+void TerminalDisplay::clearLinkTooltip()
+{
+    if (_linkTooltipTimer)
+        _linkTooltipTimer->stop();
+    _pendingLinkTooltip.clear();
+    QToolTip::hideText();
+}
+
+void TerminalDisplay::showPendingLinkTooltip()
+{
+    if (!_linkTooltipsEnabled || _pendingLinkTooltip.isEmpty())
+        return;
+    QToolTip::showText(_pendingLinkTooltipPos, _pendingLinkTooltip, this);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -428,6 +428,10 @@ public:
     void setConfirmMultilinePaste(bool confirmMultilinePaste);
     void setTrimPastedTrailingNewlines(bool trimPastedTrailingNewlines);
 
+    /** Show destination URL tooltips when hovering link hotspots. */
+    void setLinkTooltipsEnabled(bool enabled);
+    bool linkTooltipsEnabled() const;
+
     // maps a point on the widget to the position ( ie. line and column )
     // of the character at that point.
     void getCharacterPosition(const QPointF& widgetPoint,int& line,int& column) const;
@@ -652,8 +656,11 @@ private slots:
 
     void swapColorTable();
     void tripleClickTimeout();  // resets possibleTripleClick
+    void showPendingLinkTooltip();
 
 private:
+
+    void clearLinkTooltip();
 
     // -- Drawing helpers --
 
@@ -867,6 +874,10 @@ private:
     MotionAfterPasting mMotionAfterPasting;
     bool _confirmMultilinePaste;
     bool _trimPastedTrailingNewlines;
+    bool _linkTooltipsEnabled;
+    QTimer* _linkTooltipTimer;
+    QString _pendingLinkTooltip;
+    QPoint _pendingLinkTooltipPos;
 
     struct InputMethodData
     {

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -455,6 +455,25 @@ void Vt102Emulation::processWindowAttributeChange()
   // ignored, only the second char in ST ("\e\\") is appended to tokenBuffer.
   QString newValue = QString::fromWCharArray(tokenBuffer + i + 1, tokenBufferPos-i-2);
 
+  // OSC 8 ; params ; URI ST  — hyperlinks (per-screen pen state)
+  if (attributeToChange == 8)
+  {
+    // newValue is "params;URI" (URI may be empty to close the link)
+    const int sep = newValue.indexOf(QLatin1Char(';'));
+    QString params;
+    QString uri;
+    if (sep < 0) {
+      // Malformed; treat as link close
+      params.clear();
+      uri.clear();
+    } else {
+      params = newValue.left(sep);
+      uri = newValue.mid(sep + 1);
+    }
+    _currentScreen->setHyperlinkFromOsc(params, uri);
+    return;
+  }
+
   _pendingTitleUpdates[attributeToChange] = newValue;
   _titleUpdateTimer->start(20);
 }

--- a/lib/Vt102Emulation.cpp
+++ b/lib/Vt102Emulation.cpp
@@ -174,6 +174,20 @@ void Vt102Emulation::resetTokenizer()
   prevCC = 0;
 }
 
+void Vt102Emulation::clearHyperlinkPens()
+{
+  _screen[0]->clearCurrentHyperlink();
+  _screen[1]->clearCurrentHyperlink();
+}
+
+void Vt102Emulation::abortControlString()
+{
+  // Unterminated / interrupted OSC can leave OSC-8 "open" with no close.
+  // Drop the sticky pen on both screens so later prompts are not linked.
+  clearHyperlinkPens();
+  resetTokenizer();
+}
+
 void Vt102Emulation::addDigit(int digit)
 {
   if (argv[argc] < MAX_ARGUMENT)
@@ -278,11 +292,13 @@ void Vt102Emulation::receiveChar(wchar_t cc)
     // "ESCP", APC "ESC_", SOS "ESCX", and PM  "ESC^".  This matches ECMA-48 5.6 Control strings and
     // XTerm ctlseqs.html, Section "VT100 Mode", heading "Controls beginning with ESC"
     if (Cse) {
+        // CAN / SUB abort an unterminated control string (xterm-compatible recovery).
+        if (cc == CNTL('X') || cc == CNTL('Z')) {
+            abortControlString();
+            return;
+        }
         // Store in prevCC so Cte can detect the ST terminator (prevCC == 27 && cc == 92 => ESC \).
-        //
-        // Unterminated strings freeze the parser. Unlike Konsole and xterm which feature state
-        // tracking, RIS (\033c) cannot interrupt string mode, e.g. '\x1b]0;OSC-NO-TERM \033c' does
-        // not recover the terminal.
+        // RIS (ESC c) is handled below once 'c' arrives after ESC.
         prevCC = cc;
         return;
     }
@@ -291,14 +307,25 @@ void Vt102Emulation::receiveChar(wchar_t cc)
     // This means, they do neither a resetTokenizer() nor a pushToToken(). Some of them, do
     // of course. Guess this originates from a weakly layered handling of the X-on
     // X-off protocol, which comes really below this level.
-    if (cc == CNTL('X') || cc == CNTL('Z') || cc == ESC)
+    if (cc == CNTL('X') || cc == CNTL('Z') || cc == ESC) {
         resetTokenizer(); //VT100: CAN or SUB
+        // Also drop a sticky OSC-8 pen if an app was interrupted mid-link.
+        if (cc == CNTL('X') || cc == CNTL('Z'))
+            clearHyperlinkPens();
+    }
     if (cc != ESC)
     {
         processToken(TY_CTL(cc+'@' ),0,0);
         return;
     }
   }
+
+  // RIS (ESC c) may interrupt an unterminated OSC/DCS string; recover fully.
+  if (Cse && prevCC == ESC && cc == L'c') {
+      reset();
+      return;
+  }
+
   // advance the state
   addToCurrentToken(cc);
 
@@ -316,7 +343,15 @@ void Vt102Emulation::receiveChar(wchar_t cc)
         resetTokenizer();
         return;
     }
-    if (Cse         ) { prevCC = cc; return; }
+    if (Cse         ) {
+        // Oversized unterminated OSC would otherwise freeze the parser forever.
+        if (tokenBufferPos >= MAX_TOKEN_LENGTH - 1) {
+            abortControlString();
+            return;
+        }
+        prevCC = cc;
+        return;
+    }
     if (lec(3,2,'?')) { return; }
     if (lec(3,2,'>')) { return; }
     if (lec(3,2,'!')) { return; }
@@ -447,6 +482,9 @@ void Vt102Emulation::processWindowAttributeChange()
   if (tokenBuffer[i] != ';')
   {
     reportDecodingError();
+    // Broken OSC-8 must not leave a previously opened pen stuck.
+    if (attributeToChange == 8)
+      clearHyperlinkPens();
     return;
   }
 
@@ -473,6 +511,12 @@ void Vt102Emulation::processWindowAttributeChange()
     _currentScreen->setHyperlinkFromOsc(params, uri);
     return;
   }
+
+  // Shells commonly emit OSC 0/1/2 (window/icon title) at each prompt.
+  // Treat that as a boundary and close any OSC-8 pen left open by mangled
+  // or interrupted output, so the prompt itself is never stamped as a link.
+  if (attributeToChange == 0 || attributeToChange == 1 || attributeToChange == 2)
+      clearHyperlinkPens();
 
   _pendingTitleUpdates[attributeToChange] = newValue;
   _titleUpdateTimer->start(20);
@@ -879,7 +923,10 @@ void Vt102Emulation::processToken(int token, wchar_t p, int q)
     case TY_CSI_PR('r', 2004) :      restoreMode      (MODE_BracketedPaste); break; //XTERM
 
     //FIXME: weird DEC reset sequence
-    case TY_CSI_PE('p'      ) : /* IGNORED: reset         (        ) */ break;
+    case TY_CSI_PE('p'      ) : // DECSTR soft terminal reset
+                                clearHyperlinkPens();
+                                _currentScreen->setDefaultRendition();
+                                break;
 
     // DECRQM — Request Mode (Host To Terminal)
     // When the '$' intermediate byte is absorbed by the tokenizer, the natural
@@ -1163,8 +1210,13 @@ void Vt102Emulation::sendKeyEvent(QKeyEvent* event, bool fromPaste)
             emit flowControlKeyPressed(true);
             break;
         case Qt::Key_Q:
-        case Qt::Key_C: // cancel flow control
             emit flowControlKeyPressed(false);
+            break;
+        case Qt::Key_C: // cancel flow control / interrupt
+            emit flowControlKeyPressed(false);
+            // Ctrl+C often interrupts an app mid OSC-8 open; drop the sticky pen
+            // so the next shell prompt is not treated as a hyperlink.
+            clearHyperlinkPens();
             break;
         }
     }

--- a/lib/Vt102Emulation.h
+++ b/lib/Vt102Emulation.h
@@ -133,7 +133,8 @@ private:
   void resetModes();
 
   void resetTokenizer();
-  #define MAX_TOKEN_LENGTH 256 // Max length of tokens (e.g. window title)
+  // Large enough for OSC-8 URIs and long window titles
+  #define MAX_TOKEN_LENGTH 4096
   void addToCurrentToken(wchar_t cc);
   wchar_t tokenBuffer[MAX_TOKEN_LENGTH]; //FIXME: overflow?
   int tokenBufferPos;

--- a/lib/Vt102Emulation.h
+++ b/lib/Vt102Emulation.h
@@ -133,6 +133,10 @@ private:
   void resetModes();
 
   void resetTokenizer();
+  /** Abort an unterminated OSC/DCS/APC/PM/SOS string and clear OSC-8 pens. */
+  void abortControlString();
+  /** Clear current OSC-8 hyperlink pen state on both screens. */
+  void clearHyperlinkPens();
   // Large enough for OSC-8 URIs and long window titles
   #define MAX_TOKEN_LENGTH 4096
   void addToCurrentToken(wchar_t cc);

--- a/lib/qtermwidget.cpp
+++ b/lib/qtermwidget.cpp
@@ -327,7 +327,12 @@ void QTermWidget::init(int startnow)
     connect(m_impl->m_session, &Session::profileChangeCommandReceived, this, &QTermWidget::profileChanged);
     connect(m_impl->m_session, &Session::receivedData, this, &QTermWidget::receivedData);
 
-    // That's OK, FilterChain's dtor takes care of UrlFilter.
+    // That's OK, FilterChain's dtor takes care of filters.
+    // OSC-8 hyperlinks take priority over regex URL detection when both match.
+    HyperlinkFilter *hyperlinkFilter = new HyperlinkFilter();
+    connect(hyperlinkFilter, &HyperlinkFilter::activated, this, &QTermWidget::urlActivated);
+    m_impl->m_terminalDisplay->filterChain()->addFilter(hyperlinkFilter);
+
     UrlFilter *urlFilter = new UrlFilter();
     connect(urlFilter, &UrlFilter::activated, this, &QTermWidget::urlActivated);
     m_impl->m_terminalDisplay->filterChain()->addFilter(urlFilter);
@@ -846,6 +851,31 @@ void QTermWidget::setConfirmMultilinePaste(bool confirmMultilinePaste) {
 
 void QTermWidget::setTrimPastedTrailingNewlines(bool trimPastedTrailingNewlines) {
     m_impl->m_terminalDisplay->setTrimPastedTrailingNewlines(trimPastedTrailingNewlines);
+}
+
+void QTermWidget::setOsc8HyperlinksEnabled(bool enabled)
+{
+    if (auto* filter = m_impl->m_terminalDisplay->filterChain()->getHyperlinkFilter()) {
+        filter->setEnabled(enabled);
+        m_impl->m_terminalDisplay->processFilters();
+    }
+}
+
+bool QTermWidget::osc8HyperlinksEnabled() const
+{
+    if (auto* filter = m_impl->m_terminalDisplay->filterChain()->getHyperlinkFilter())
+        return filter->isEnabled();
+    return false;
+}
+
+void QTermWidget::setLinkTooltipsEnabled(bool enabled)
+{
+    m_impl->m_terminalDisplay->setLinkTooltipsEnabled(enabled);
+}
+
+bool QTermWidget::linkTooltipsEnabled() const
+{
+    return m_impl->m_terminalDisplay->linkTooltipsEnabled();
 }
 
 QString QTermWidget::wordCharacters() const

--- a/lib/qtermwidget.h
+++ b/lib/qtermwidget.h
@@ -260,6 +260,11 @@ public:
     void setConfirmMultilinePaste(bool confirmMultilinePaste) override;
     void setTrimPastedTrailingNewlines(bool trimPastedTrailingNewlines) override;
 
+    void setOsc8HyperlinksEnabled(bool enabled) override;
+    bool osc8HyperlinksEnabled() const override;
+    void setLinkTooltipsEnabled(bool enabled) override;
+    bool linkTooltipsEnabled() const override;
+
     QString wordCharacters() const override;
     void setWordCharacters(const QString& chars) override;
 

--- a/lib/qtermwidget_interface.h
+++ b/lib/qtermwidget_interface.h
@@ -97,12 +97,16 @@ class QTermWidgetInterface {
    virtual void setBoldIntense(bool boldIntense) = 0;
    virtual void setConfirmMultilinePaste(bool confirmMultilinePaste) = 0;
    virtual void setTrimPastedTrailingNewlines(bool trimPastedTrailingNewlines) = 0;
+   virtual void setOsc8HyperlinksEnabled(bool enabled) = 0;
+   virtual bool osc8HyperlinksEnabled() const = 0;
+   virtual void setLinkTooltipsEnabled(bool enabled) = 0;
+   virtual bool linkTooltipsEnabled() const = 0;
    virtual QString wordCharacters() const = 0;
    virtual void setWordCharacters(const QString& chars) = 0;
    virtual QTermWidgetInterface* createWidget(int startnow) const = 0;
    virtual void autoHideMouseAfter(int delay) = 0;
 };
 
-#define QTermWidgetInterface_iid "lxqt.qtermwidget.QTermWidgetInterface/1.5"
+#define QTermWidgetInterface_iid "lxqt.qtermwidget.QTermWidgetInterface/1.6"
 
 Q_DECLARE_INTERFACE(QTermWidgetInterface, QTermWidgetInterface_iid)


### PR DESCRIPTION
## ✨ OSC-8 Hyperlinks — clickable modern terminal links!

### 📝 Summary
Adds **OSC-8 hyperlink** support so apps can embed real clickable links (label ≠ URL), not only regex URL detection.

QTermWidget is historically based on KDE’s Konsole. This change continues that lineage: OSC-8 handling was inspired by / adapted from Konsole’s hyperlink support, then integrated into qtermwidget’s existing filter/hotspot and urlActivated machinery.

Addresses the OSC-8 part of [#649](https://github.com/lxqt/qtermwidget/issues/649).

- 🧩 **Parse** `OSC 8 ; params ; URI ST/BEL` in `Vt102Emulation`
- 📦 **Per-cell** `hyperlinkId` + shared `HyperlinkTable` (compact, history-friendly)
- 🖱 **`HyperlinkFilter`** → Link hotspots (underline, click, context menu)
- 🔗 Reuses existing `urlActivated` path (works with QTerminal out of the box)
- 🛡 Safer URIs: allow `http` / `https` / `file` / `mailto` / `ftp`; reject whitespace / junk payloads
- 💬 Hover **tooltips** with destination URL + **dwell delay** (~400ms) so fast mouse sweeps stay quiet
- 🎛 Public API: `setOsc8HyperlinksEnabled()` / `setLinkTooltipsEnabled()` (interface **1.6**)
- 📚 Bigger OSC token buffer (**4096**) for longer URIs

- Based on the [OSC-8 hyperlink specification](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
- Approach and prior art from KDE Konsole’s OSC-8 / hyperlink support
(see Konsole’s implementation / [KDE Bug 379294](https://bugs.kde.org/show_bug.cgi?id=379294))
- Adapted to qtermwidget’s architecture (Character / Screen / Filter / TerminalDisplay) rather than a straight copy of Konsole internals


### 🔗 Related
- Addresses partially: https://github.com/lxqt/qtermwidget/issues/649 (OSC-8 part)

---

### 🖥️ Companion PR — **qterminal**
https://github.com/lxqt/qterminal/pull/1348

<img width="1438" height="683" alt="image" src="https://github.com/user-attachments/assets/9d91b15c-4232-49d1-90b0-f95bd9c08fe4" />
