### PR TITLE
Removed a useless debug message

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -3540,8 +3540,7 @@ void TerminalDisplay::dropEvent(QDropEvent* event)
   QString dropText;
   if (!urls.isEmpty())
   {
-      // TODO/FIXME: escape or quote pasted things if necessary...
-      qDebug() << "TerminalDisplay: handling urls. It can be broken. Report any errors, please";
+    // TODO/FIXME: escape or quote pasted things if necessary...
     for ( int i = 0 ; i < urls.count() ; i++ )
     {
         //KUrl url = KIO::NetAccess::mostLocalUrl( urls[i] , 0 );


### PR DESCRIPTION
It's useless (and annoying) because all reports are welcome, not just this one.

I hadn't seen it before because I have `*.warning=false` in `~/.config/QtProject/qtlogging.ini`.

<!--- If this pull request is related to a change in the API, please       --->
<!--- remember to update the documentation accordingly in README.md        --->

