### PR TITLE
fix cursor drawing routine wrt. QRectF mechanics

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -778,28 +778,25 @@ void TerminalDisplay::drawCursor(QPainter& painter,
 {
     QRectF cursorRect = rect;
     cursorRect.setHeight(_fontHeight - _lineSpacing - 1);
+    cursorRect.translate(0,(rect.height()-cursorRect.height())/2.0);
 
     if (!_cursorBlinking)
     {
-       if ( _cursorColor.isValid() )
-           painter.setPen(_cursorColor);
-       else
-           painter.setPen(foregroundColor);
+        if ( _cursorColor.isValid() )
+            painter.setPen(_cursorColor);
+        else
+            painter.setPen(foregroundColor);
 
-       if ( _cursorShape == Emulation::KeyboardCursorShape::BlockCursor )
-       {
-            // draw the cursor outline, adjusting the area so that
-            // it is draw entirely inside 'rect'
-            float penWidth = qMax(1,painter.pen().width());
+        // draw the cursor outline, adjusting the area so that
+        // it is draw entirely inside 'rect'
+        float halfStroke = qMax(1,painter.pen().width())/2.0f;
+        cursorRect.adjust(halfStroke, halfStroke, -halfStroke, -halfStroke);
 
-            painter.drawRect(cursorRect.adjusted(penWidth/2,
-                                                 penWidth/2,
-                                                 - penWidth/2,
-                                                 - penWidth/2));
+        if ( _cursorShape == Emulation::KeyboardCursorShape::BlockCursor )
+        {
             if ( hasFocus() )
             {
-                painter.fillRect(cursorRect, _cursorColor.isValid() ? _cursorColor : foregroundColor);
-
+                painter.setBrush(painter.pen().color());
                 if ( !_cursorColor.isValid() )
                 {
                     // invert the colour used to draw the text to ensure that the character at
@@ -807,17 +804,24 @@ void TerminalDisplay::drawCursor(QPainter& painter,
                     invertCharacterColor = true;
                 }
             }
-       }
-       else if ( _cursorShape == Emulation::KeyboardCursorShape::UnderlineCursor )
+            painter.drawRect(cursorRect);
+        }
+        else if ( _cursorShape == Emulation::KeyboardCursorShape::UnderlineCursor )
+        {
+            cursorRect.adjust(halfStroke, halfStroke, -halfStroke, -halfStroke);
             painter.drawLine(cursorRect.left(),
                              cursorRect.bottom(),
                              cursorRect.right(),
                              cursorRect.bottom());
-       else if ( _cursorShape == Emulation::KeyboardCursorShape::IBeamCursor )
+        }
+        else if ( _cursorShape == Emulation::KeyboardCursorShape::IBeamCursor )
+        {
+            cursorRect.adjust(halfStroke, halfStroke, -halfStroke, -halfStroke);
             painter.drawLine(cursorRect.left(),
                              cursorRect.top(),
                              cursorRect.left(),
                              cursorRect.bottom());
+        }
 
     }
 }


### PR DESCRIPTION
The rect got correctly adjusted to account for the half pen when drawing a rect, but the same painter logic affects the underscore and I-beam
Depending on the specific position the I-beam occasionally covers to pixels here [likely because of the QRectF], so account for that by pushing it in an entire pen width (the additional gap is neglectable against a still cursor artifact when blinking or residuals when moving)
The underscore is likewise afected with its leftmost pixel.

Probably fixes https://github.com/lxqt/qterminal/issues/647
[didn't find a bug for qtermwidget but generally a lot are reported against qterminal as the user facing frontend]

Also some minor code improvements, there's no need to paint the full rect twice ;)

