### PR TITLE
Background images

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -147,6 +147,86 @@ inline int TerminalDisplay::loc(int x, int y) const
 static QPoint gs_deadSpot(-1,-1);
 static QPoint gs_futureDeadSpot;
 std::shared_ptr<QTimer> TerminalDisplay::_hideMouseTimer;
+typedef QPair<QPixmap,QList<void*>> SharedPixmap;
+class ScaledPixmapCache : public QMap<QString,SharedPixmap>
+{
+    public:
+        QSize attach(void *hook, QString imageFile)
+        {
+            ScaledPixmapCache::iterator it = find(imageFile);
+            if (it == end())
+            {
+                QPixmap pix;
+                if (!pix.load(imageFile))
+                    return QSize(); // bogus image path, stupid user
+                it = insert(imageFile, SharedPixmap(pix, QList<void*>() << hook));
+                return pix.size();
+            }
+            if (!it->second.contains(hook))
+                it->second << hook;
+            return it->first.size();
+        }
+        bool detach(void *hook, QString imageFile)
+        {
+            ScaledPixmapCache::iterator it = find(imageFile);
+            if (it == end() || !it->second.contains(hook))
+                return false;
+            it->second.removeAll(hook);
+            if (it->second.isEmpty())
+                erase(it);
+            return true;
+        }
+        void detach(void *hook, bool onlyScales = false)
+        {
+            ScaledPixmapCache::iterator it = begin();
+            while (it != end())
+            {
+                if (onlyScales && !it.key().startsWith(QStringLiteral(":$:")))
+                {
+                    ++it;
+                    continue;
+                }
+                it->second.removeAll(hook);
+                if (it->second.isEmpty())
+                    it = erase(it);
+                else
+                    ++it;
+            }
+        }
+        QPixmap scaled(void *hook, QString imageFile, QSize sz = QSize())
+        {
+            if (!sz.isValid())
+            {   // return unscaled base
+                detach(hook, true);
+                ScaledPixmapCache::const_iterator it = constFind(imageFile);
+                return it == constEnd() ? QPixmap() : it->first;
+            }
+            const QString key = QStringLiteral(":$:%1:%2:%3").arg(sz.width()).arg(sz.height()).arg(imageFile);
+            ScaledPixmapCache::iterator it = find(key);
+            if (it != end())
+            {
+                if (!it->second.contains(hook))
+                {
+                    detach(hook, true); // invalidates iterator
+                    it = find(key);
+                    it->second << hook;
+                }
+                return it->first;
+            }
+            QPixmap base = scaled(hook, imageFile, QSize());
+            if (base.isNull())
+            {
+                qDebug() << "Scaled " << imageFile << " requested, but was not attached!";
+                return base;
+            }
+            if (base.size() == sz)
+                return base; //yay, free scale
+            base = base.scaled(sz, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+            insert(key, SharedPixmap(base, QList<void*>() << hook));
+            return base;
+        }
+};
+static ScaledPixmapCache gs_backgroundCache;
 
 ScreenWindow* TerminalDisplay::screenWindow() const
 {
@@ -468,6 +548,7 @@ TerminalDisplay::TerminalDisplay(QWidget *parent)
 
 TerminalDisplay::~TerminalDisplay()
 {
+  gs_backgroundCache.detach(this);
   disconnect(_blinkTimer);
   disconnect(_blinkCursorTimer);
   if (_hideMouseTimer)
@@ -741,16 +822,12 @@ void TerminalDisplay::setOpacity(qreal opacity)
 
 void TerminalDisplay::setBackgroundImage(const QString& backgroundImage)
 {
-    if (!backgroundImage.isEmpty())
-    {
-        _backgroundImage.load(backgroundImage);
-        setAttribute(Qt::WA_OpaquePaintEvent, false);
-    }
-    else
-    {
-        _backgroundImage = QPixmap();
-        setAttribute(Qt::WA_OpaquePaintEvent, true);
-    }
+    if (_backgroundImage == backgroundImage)
+        return;
+    gs_backgroundCache.detach(this, _backgroundImage);
+    _backgroundImage = backgroundImage;
+    _backgroundImageSize = gs_backgroundCache.attach(this, _backgroundImage);
+    setAttribute(Qt::WA_OpaquePaintEvent, _backgroundImageSize.isEmpty());
 }
 
 void TerminalDisplay::setBackgroundMode(BackgroundMode mode)
@@ -765,7 +842,7 @@ void TerminalDisplay::drawBackground(QPainter& painter, const QRect& rect, const
         // left to the widget style for a consistent look.
         if ( useOpacitySetting )
         {
-            if (_backgroundImage.isNull()) {
+            if (testAttribute(Qt::WA_OpaquePaintEvent)) {
                 QColor color(backgroundColor);
                 color.setAlphaF(_opacity);
 
@@ -1451,12 +1528,14 @@ void TerminalDisplay::leaveEvent(QEvent* event)
   QWidget::leaveEvent(event);
 }
 
+#include <QElapsedTimer>
+
 void TerminalDisplay::paintEvent( QPaintEvent* pe )
 {
   QPainter paint(this);
   QRect cr = contentsRect();
 
-  if ( !_backgroundImage.isNull() )
+  if (!_backgroundImageSize.isEmpty())
   {
     QColor background = _colorTable[DEFAULT_BACK_COLOR].color;
     if (_opacity < static_cast<qreal>(1))
@@ -1475,83 +1554,63 @@ void TerminalDisplay::paintEvent( QPaintEvent* pe )
     paint.save();
     paint.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
 
-    if (_backgroundMode == Stretch)
-    { // scale the image without keeping its proportions to fill the screen
-        paint.drawPixmap(cr, _backgroundImage, _backgroundImage.rect());
-    }
-    else if (_backgroundMode == Zoom)
-    { // zoom in/out the image to fit it
-        QRect r = _backgroundImage.rect();
-        qreal wRatio = static_cast<qreal>(cr.width()) / r.width();
-        qreal hRatio = static_cast<qreal>(cr.height()) / r.height();
-        if (wRatio > hRatio)
-        {
-            r.setWidth(qRound(r.width() * hRatio));
-            r.setHeight(cr.height());
-        }
-        else
-        {
-            r.setHeight(qRound(r.height() * wRatio));
-            r.setWidth(cr.width());
-        }
-        r.moveCenter(cr.center());
-        paint.drawPixmap(r, _backgroundImage, _backgroundImage.rect());
-    }
-    else if (_backgroundMode == Fit)
-    { // if the image is bigger than the terminal, zoom it out to fit it
-        QRect r = _backgroundImage.rect();
-        qreal wRatio = static_cast<qreal>(cr.width()) / r.width();
-        qreal hRatio = static_cast<qreal>(cr.height()) / r.height();
-        if (r.width() > cr.width())
-        {
-            if (wRatio <= hRatio)
-            {
-                r.setHeight(qRound(r.height() * wRatio));
-                r.setWidth(cr.width());
-            }
-            else
-            {
-                r.setWidth(qRound(r.width() * hRatio));
-                r.setHeight(cr.height());
-            }
-        }
-        else if (r.height() > cr.height())
-        {
-            r.setWidth(qRound(r.width() * hRatio));
-            r.setHeight(cr.height());
-        }
-        r.moveCenter(cr.center());
-        paint.drawPixmap(r, _backgroundImage, _backgroundImage.rect());
-    }
-    else if (_backgroundMode == Center)
-    { // center the image without scaling/zooming
-        QRect r = _backgroundImage.rect();
-        r.moveCenter(cr.center());
-        paint.drawPixmap(r.topLeft(), _backgroundImage);
-    }
-    else if (_backgroundMode == Fill)
-    { // zoom in/out the image to fill all empty space
-        QRect r = _backgroundImage.rect();
-        qreal wRatio = static_cast<qreal>(cr.width()) / r.width();
-        qreal hRatio = static_cast<qreal>(cr.height()) / r.height();
-        if (wRatio < hRatio)
-        {
-            r.setWidth(qRound(r.width() * hRatio));
-            r.setHeight(cr.height());
-        }
-        else
-        {
-            r.setHeight(qRound(r.height() * wRatio));
-            r.setWidth(cr.width());
-        }
-        r.moveCenter(cr.center());
-        paint.drawPixmap(r, _backgroundImage, _backgroundImage.rect());
-    }
-    else //if (_backgroundMode == None)
+    QRect bgr(QPoint(0,0), _backgroundImageSize);
+    switch (_backgroundMode)
     {
-        paint.drawPixmap(0, 0, _backgroundImage);
+        case Stretch:
+        { // scale the image without keeping its proportions to fill the screen
+            bgr.setSize(cr.size());
+            break;
+        }
+        case Zoom:
+            // zoom in/out the image to fit it
+            [[fallthrough]];
+        case Fill:
+            // zoom in/out the image to fill all empty space
+            [[fallthrough]];
+        case Fit:
+        { // if the image is bigger than the terminal, zoom it out to fit it
+            if (_backgroundMode != Fit || bgr.width() > cr.width() || bgr.height() > cr.height())
+            {
+                qreal wRatio = static_cast<qreal>(cr.width()) / bgr.width();
+                qreal hRatio = static_cast<qreal>(cr.height()) / bgr.height();
+                if ((_backgroundMode != Fill && wRatio > hRatio) ||
+                    (_backgroundMode == Fill && wRatio < hRatio))
+                {
+                    bgr.setWidth(qRound(bgr.width() * hRatio));
+                    bgr.setHeight(cr.height());
+                }
+                else
+                {
+                    bgr.setHeight(qRound(bgr.height() * wRatio));
+                    bgr.setWidth(cr.width());
+                }
+            }
+            bgr.moveCenter(cr.center());
+            break;
+        }
+        case Center:
+        { // center the image without scaling/zooming
+            bgr.moveCenter(cr.center());
+            bgr.setSize(QSize()); // invalidate for unscaled
+            break;
+        }
+        case None:
+            [[fallthrough]];
+        default:
+            bgr.setSize(QSize()); // invalidate for unscaled
+            break;
     }
 
+//    QElapsedTimer profiler;
+//    profiler.start();
+      qreal ratio = window() ? window()->devicePixelRatio() : 1.0;
+      QPixmap pix = gs_backgroundCache.scaled(this, _backgroundImage, bgr.size() * ratio);
+      pix.setDevicePixelRatio(ratio);
+//    for (int i=0;i<1000;++i)
+      paint.drawPixmap(bgr.topLeft(), pix);
+//    paint.drawPixmap(bgr, pix, pix.rect());
+//    qDebug() << profiler.elapsed() << cr;
     paint.restore();
   }
 

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -1562,9 +1562,15 @@ void TerminalDisplay::paintEvent( QPaintEvent* pe )
             bgr.moveCenter(cr.center());
             break;
         }
-        case Center:
-        { // center the image without scaling/zooming
-            bgr.moveCenter(cr.center());
+        // position the image without scaling/zooming
+        case Center:        bgr.moveCenter(cr.center());            break;
+        case TopLeft:       bgr.moveTopLeft(cr.topLeft());          break;
+        case TopRight:      bgr.moveTopRight(cr.topRight());        break;
+        case BottomLeft:    bgr.moveBottomLeft(cr.bottomLeft());    break;
+        case BottomRight:   bgr.moveBottomRight(cr.bottomRight());  break;
+        case Tiled:
+        {
+            paint.setBrush(pix);
             break;
         }
         case None:
@@ -1573,7 +1579,10 @@ void TerminalDisplay::paintEvent( QPaintEvent* pe )
             break;
     }
 
-    paint.drawPixmap(bgr, pix, pix.rect());
+    if (_backgroundMode == Tiled)
+        paint.drawRect(cr);
+    else
+        paint.drawPixmap(bgr, pix, pix.rect());
     paint.restore();
   }
 

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -147,24 +147,28 @@ inline int TerminalDisplay::loc(int x, int y) const
 static QPoint gs_deadSpot(-1,-1);
 static QPoint gs_futureDeadSpot;
 std::shared_ptr<QTimer> TerminalDisplay::_hideMouseTimer;
+
+// Share the smae background pixmap across mutliple tabs, windows, …
 typedef QPair<QPixmap,QList<void*>> SharedPixmap;
 class ScaledPixmapCache : public QMap<QString,SharedPixmap>
 {
     public:
-        QSize attach(void *hook, QString imageFile)
+        bool attach(void *hook, QString imageFile)
         {
+            if (imageFile.isEmpty())
+                return false;
             ScaledPixmapCache::iterator it = find(imageFile);
             if (it == end())
             {
                 QPixmap pix;
                 if (!pix.load(imageFile))
-                    return QSize(); // bogus image path, stupid user
+                    return false; // bogus image path, stupid user
                 it = insert(imageFile, SharedPixmap(pix, QList<void*>() << hook));
-                return pix.size();
+                return true;
             }
             if (!it->second.contains(hook))
                 it->second << hook;
-            return it->first.size();
+            return true;
         }
         bool detach(void *hook, QString imageFile)
         {
@@ -176,16 +180,11 @@ class ScaledPixmapCache : public QMap<QString,SharedPixmap>
                 erase(it);
             return true;
         }
-        void detach(void *hook, bool onlyScales = false)
+        void detach(void *hook)
         {
             ScaledPixmapCache::iterator it = begin();
             while (it != end())
             {
-                if (onlyScales && !it.key().startsWith(QStringLiteral(":$:")))
-                {
-                    ++it;
-                    continue;
-                }
                 it->second.removeAll(hook);
                 if (it->second.isEmpty())
                     it = erase(it);
@@ -193,37 +192,10 @@ class ScaledPixmapCache : public QMap<QString,SharedPixmap>
                     ++it;
             }
         }
-        QPixmap scaled(void *hook, QString imageFile, QSize sz = QSize())
+        QPixmap pixmap(QString imageFile)
         {
-            if (!sz.isValid())
-            {   // return unscaled base
-                detach(hook, true);
-                ScaledPixmapCache::const_iterator it = constFind(imageFile);
-                return it == constEnd() ? QPixmap() : it->first;
-            }
-            const QString key = QStringLiteral(":$:%1:%2:%3").arg(sz.width()).arg(sz.height()).arg(imageFile);
-            ScaledPixmapCache::iterator it = find(key);
-            if (it != end())
-            {
-                if (!it->second.contains(hook))
-                {
-                    detach(hook, true); // invalidates iterator
-                    it = find(key);
-                    it->second << hook;
-                }
-                return it->first;
-            }
-            QPixmap base = scaled(hook, imageFile, QSize());
-            if (base.isNull())
-            {
-                qDebug() << "Scaled " << imageFile << " requested, but was not attached!";
-                return base;
-            }
-            if (base.size() == sz)
-                return base; //yay, free scale
-            base = base.scaled(sz, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-            insert(key, SharedPixmap(base, QList<void*>() << hook));
-            return base;
+            ScaledPixmapCache::const_iterator it = constFind(imageFile);
+            return it == constEnd() ? QPixmap() : it->first;
         }
 };
 static ScaledPixmapCache gs_backgroundCache;
@@ -826,8 +798,10 @@ void TerminalDisplay::setBackgroundImage(const QString& backgroundImage)
         return;
     gs_backgroundCache.detach(this, _backgroundImage);
     _backgroundImage = backgroundImage;
-    _backgroundImageSize = gs_backgroundCache.attach(this, _backgroundImage);
-    setAttribute(Qt::WA_OpaquePaintEvent, _backgroundImageSize.isEmpty());
+    const bool haveImage = gs_backgroundCache.attach(this, _backgroundImage);
+    if (!haveImage)
+        _backgroundImage = QString();
+    setAttribute(Qt::WA_OpaquePaintEvent, !haveImage);
 }
 
 void TerminalDisplay::setBackgroundMode(BackgroundMode mode)
@@ -1528,14 +1502,12 @@ void TerminalDisplay::leaveEvent(QEvent* event)
   QWidget::leaveEvent(event);
 }
 
-#include <QElapsedTimer>
-
 void TerminalDisplay::paintEvent( QPaintEvent* pe )
 {
   QPainter paint(this);
   QRect cr = contentsRect();
 
-  if (!_backgroundImageSize.isEmpty())
+  if (!_backgroundImage.isEmpty())
   {
     QColor background = _colorTable[DEFAULT_BACK_COLOR].color;
     if (_opacity < static_cast<qreal>(1))
@@ -1554,7 +1526,8 @@ void TerminalDisplay::paintEvent( QPaintEvent* pe )
     paint.save();
     paint.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
 
-    QRect bgr(QPoint(0,0), _backgroundImageSize);
+    QPixmap pix = gs_backgroundCache.pixmap(_backgroundImage);
+    QRect bgr = pix.rect();
     switch (_backgroundMode)
     {
         case Stretch:
@@ -1592,25 +1565,15 @@ void TerminalDisplay::paintEvent( QPaintEvent* pe )
         case Center:
         { // center the image without scaling/zooming
             bgr.moveCenter(cr.center());
-            bgr.setSize(QSize()); // invalidate for unscaled
             break;
         }
         case None:
             [[fallthrough]];
         default:
-            bgr.setSize(QSize()); // invalidate for unscaled
             break;
     }
 
-//    QElapsedTimer profiler;
-//    profiler.start();
-      qreal ratio = window() ? window()->devicePixelRatio() : 1.0;
-      QPixmap pix = gs_backgroundCache.scaled(this, _backgroundImage, bgr.size() * ratio);
-      pix.setDevicePixelRatio(ratio);
-//    for (int i=0;i<1000;++i)
-      paint.drawPixmap(bgr.topLeft(), pix);
-//    paint.drawPixmap(bgr, pix, pix.rect());
-//    qDebug() << profiler.elapsed() << cr;
+    paint.drawPixmap(bgr, pix, pix.rect());
     paint.restore();
   }
 

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -856,7 +856,8 @@ private:
 
     qreal _opacity;
 
-    QPixmap _backgroundImage;
+    QString _backgroundImage;
+    QSize _backgroundImageSize;
     BackgroundMode _backgroundMode;
 
     // list of filters currently applied to the display.  used for links and

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -68,7 +68,12 @@ namespace Konsole
         Zoom,
         Fit,
         Center,
-        Fill
+        Fill,
+        Tiled,
+        TopLeft,
+        TopRight,
+        BottomLeft,
+        BottomRight
     };
 
 extern unsigned short vt100_graphics[32];

--- a/lib/TerminalDisplay.h
+++ b/lib/TerminalDisplay.h
@@ -857,7 +857,6 @@ private:
     qreal _opacity;
 
     QString _backgroundImage;
-    QSize _backgroundImageSize;
     BackgroundMode _backgroundMode;
 
     // list of filters currently applied to the display.  used for links and


### PR DESCRIPTION
I noticed that qterminal doesn't re-use the same image across tabs etc. and can quickly eat RAM this way (eg. if users would use the terminal as desktop window or so)

While at it I also used the cache to address this for pre-scaled images, but while it drastically outperforms "regular" painting, activating the smooth transitions outperforms the cached variant (god knows how, it's not the lookup, I left some commented profiling code in the first patch.
So the second patch simplifies that (merge them if you will, I just wanted to preserve the cache code)

Also, after refactoring the paint routine I added more background modes - bottom right corner is a nifty space for logos and I'm pretty sure I stumbled over a feature request for tiled background (which is reasonable and I have a bunch of nice tiles around I used with urxvt at some point :) )