### PR TITLE
Apply the filters to the unbound image

### DIFF
--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -58,8 +58,11 @@ using namespace Konsole;
 #define loc(X,Y) ((Y)*columns+(X))
 #endif
 
-
 Character Screen::defaultChar = Character(' ',
+        CharacterColor(COLOR_SPACE_DEFAULT,DEFAULT_FORE_COLOR),
+        CharacterColor(COLOR_SPACE_DEFAULT,DEFAULT_BACK_COLOR),
+        DEFAULT_RENDITION);
+Character Screen::nullChar = Character('\0',
         CharacterColor(COLOR_SPACE_DEFAULT,DEFAULT_FORE_COLOR),
         CharacterColor(COLOR_SPACE_DEFAULT,DEFAULT_BACK_COLOR),
         DEFAULT_RENDITION);
@@ -452,24 +455,25 @@ void Screen::updateEffectiveRendition()
         effectiveForeground.setIntensive();
 }
 
-void Screen::copyFromHistory(Character* dest, int startLine, int count) const
+
+void Screen::copyFromHistory(Character* dest, int startLine, int count, int cols) const
 {
     Q_ASSERT( startLine >= 0 && count > 0 && startLine + count <= history->getLines() );
 
     for (int line = startLine; line < startLine + count; line++)
     {
-        const int length = qMin(columns,history->getLineLen(line));
-        const int destLineOffset  = (line-startLine)*columns;
+        const int length = qMin(cols,history->getLineLen(line));
+        const int destLineOffset  = (line-startLine)*cols;
 
         history->getCells(line,0,length,dest + destLineOffset);
 
-        for (int column = length; column < columns; column++)
-            dest[destLineOffset+column] = defaultChar;
+        for (int column = length; column < cols; column++)
+            dest[destLineOffset+column] = nullChar;
 
         // invert selected text
         if (selBegin !=-1)
         {
-            for (int column = 0; column < columns; column++)
+            for (int column = 0; column < cols; column++)
             {
                 if (isSelected(column,line))
                 {
@@ -480,21 +484,22 @@ void Screen::copyFromHistory(Character* dest, int startLine, int count) const
     }
 }
 
-void Screen::copyFromScreen(Character* dest , int startLine , int count) const
+void Screen::copyFromScreen(Character* dest , int startLine , int count, int cols) const
 {
     Q_ASSERT( startLine >= 0 && count > 0 && startLine + count <= lines );
 
     for (int line = startLine; line < (startLine+count) ; line++)
     {
-        int srcLineStartIndex  = line*columns;
-        int destLineStartIndex = (line-startLine)*columns;
+        int srcLineStartIndex  = line*cols;
+        int destLineStartIndex = (line-startLine)*cols;
+        Character *pad = (lineProperties[line] & LINE_WRAPPED) ? &nullChar : &defaultChar;
 
-        for (int column = 0; column < columns; column++)
+        for (int column = 0; column < cols; column++)
         {
             int srcIndex = srcLineStartIndex + column;
             int destIndex = destLineStartIndex + column;
 
-            dest[destIndex] = screenLines[srcIndex/columns].value(srcIndex%columns,defaultChar);
+            dest[destIndex] = screenLines[srcIndex/cols].value(srcIndex%cols,*pad);
 
             // invert selected text
             if (selBegin != -1 && isSelected(column,line + history->getLines()))
@@ -504,14 +509,16 @@ void Screen::copyFromScreen(Character* dest , int startLine , int count) const
     }
 }
 
-void Screen::getImage( Character* dest, int size, int startLine, int endLine ) const
+void Screen::getImage( Character* dest, int size, int startLine, int endLine, int cols) const
 {
     Q_ASSERT( startLine >= 0 );
     Q_ASSERT( endLine >= startLine && endLine < history->getLines() + lines );
 
+    if (cols < 0)
+        cols = columns;
     const int mergedLines = endLine - startLine + 1;
 
-    Q_ASSERT( size >= mergedLines * columns );
+    Q_ASSERT( size >= mergedLines * cols );
     Q_UNUSED( size )
 
     const int linesInHistoryBuffer = qBound(0,history->getLines()-startLine,mergedLines);
@@ -519,25 +526,50 @@ void Screen::getImage( Character* dest, int size, int startLine, int endLine ) c
 
     // copy lines from history buffer
     if (linesInHistoryBuffer > 0)
-        copyFromHistory(dest,startLine,linesInHistoryBuffer);
+        copyFromHistory(dest,startLine,linesInHistoryBuffer,cols);
 
     // copy lines from screen buffer
     if (linesInScreenBuffer > 0)
-        copyFromScreen(dest + linesInHistoryBuffer*columns,
+        copyFromScreen(dest + linesInHistoryBuffer*cols,
                 startLine + linesInHistoryBuffer - history->getLines(),
-                linesInScreenBuffer);
+                linesInScreenBuffer,cols);
 
     // invert display when in screen mode
     if (getMode(MODE_Screen))
     {
-        for (int i = 0; i < mergedLines*columns; i++)
+        for (int i = 0; i < mergedLines*cols; i++)
             reverseRendition(dest[i]); // for reverse display
     }
 
     // mark the character at the current cursor position
     int cursorIndex = loc(cuX, cuY + linesInHistoryBuffer);
-    if(getMode(MODE_Cursor) && cursorIndex < columns*mergedLines)
+    if(getMode(MODE_Cursor) && cursorIndex < cols*mergedLines)
+    {
         dest[cursorIndex].rendition |= RE_CURSOR;
+        // the cursor would disappear over a non-printable character
+        if (dest[cursorIndex].character == '\0')
+            dest[cursorIndex].character = ' ';
+        // because of wide chars also check the next or you get a double-width cursor
+        if (cursorIndex+1 < cols*mergedLines && dest[cursorIndex+1].character == '\0')
+            dest[cursorIndex+1].character = ' ';
+    }
+}
+
+int Screen::getColumnCeil(int startLine , int endLine) const
+{
+    Q_ASSERT( startLine >= 0 );
+    Q_ASSERT( endLine >= startLine && endLine < history->getLines() + lines );
+
+    const int mergedLines = endLine - startLine + 1;
+    const int linesInHistoryBuffer = qBound(0,history->getLines()-startLine,mergedLines);
+    const int linesInScreenBuffer = mergedLines - linesInHistoryBuffer;
+    int cols = 0;
+    for (int i = startLine; i < startLine+linesInHistoryBuffer; ++i)
+        cols = qMax(cols, history->getLineLen(i));
+    startLine += linesInHistoryBuffer - history->getLines();
+    for (int i = startLine; i < startLine+linesInScreenBuffer; ++i)
+        cols = qMax(cols, screenLines[i].size());
+    return cols;
 }
 
 QVector<LineProperty> Screen::getLineProperties( int startLine , int endLine ) const
@@ -1586,5 +1618,5 @@ void Screen::setLineProperty(LineProperty property , bool enable)
 void Screen::fillWithDefaultChar(Character* dest, int count)
 {
     for (int i=0;i<count;i++)
-        dest[i] = defaultChar;
+        dest[i] = defaultChar; // pad the entire tail w/ blanks to clean up after eg. mc
 }

--- a/lib/Screen.cpp
+++ b/lib/Screen.cpp
@@ -1409,7 +1409,8 @@ void Screen::writeToStream(TerminalCharacterDecoder* decoder,
                 count,
                 decoder,
                 appendNewLine,
-                preserveLineBreaks );
+                preserveLineBreaks,
+                !(y == bottom || blockSelectionMode));
 
         // if the selection goes beyond the end of the last line then
         // append a new line character.
@@ -1430,7 +1431,8 @@ int Screen::copyLineToStream(int line ,
         int count,
         TerminalCharacterDecoder* decoder,
         bool appendNewLine,
-        bool preserveLineBreaks) const
+        bool preserveLineBreaks,
+        bool fullLine) const
 {
     //buffer to hold characters for decoding
     //the buffer is static to avoid initialising every
@@ -1475,15 +1477,15 @@ int Screen::copyLineToStream(int line ,
     }
     else
     {
-        if ( count == -1 )
-            count = columns - start;
-
-        Q_ASSERT( count >= 0 );
-
         const int screenLine = line-history->getLines();
 
         Character* data = screenLines[screenLine].data();
         int length = screenLines[screenLine].count();
+
+        if ( count == -1 )
+            count = (fullLine ? length : columns) - start;
+
+        Q_ASSERT( count >= 0 );
 
         //retrieve line from screen image
         for (int i=start;i < qMin(start+count,length);i++)

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -383,8 +383,16 @@ public:
      * @param size Size of @p dest in Characters
      * @param startLine Index of first line to copy
      * @param endLine Index of last line to copy
+     * @param cols optional width of the image, defaults to screen width
      */
-    void getImage( Character* dest , int size , int startLine , int endLine ) const;
+    void getImage( Character* dest , int size , int startLine , int endLine, int cols = -1) const;
+
+    /**
+     * Returns the width of the longest line between
+     * @param startLine Index of first line to count
+     * @param endLine Index of last line to count
+     */
+    int getColumnCeil(int startLine , int endLine) const;
 
     /**
      * Returns the additional attributes associated with lines in the image.
@@ -641,10 +649,10 @@ private:
                        int endIndex, bool preserveLineBreaks = true) const;
     // copies 'count' lines from the screen buffer into 'dest',
     // starting from 'startLine', where 0 is the first line in the screen buffer
-    void copyFromScreen(Character* dest, int startLine, int count) const;
+    void copyFromScreen(Character* dest, int startLine, int count, int cols) const;
     // copies 'count' lines from the history buffer into 'dest',
     // starting from 'startLine', where 0 is the first line in the history
-    void copyFromHistory(Character* dest, int startLine, int count) const;
+    void copyFromHistory(Character* dest, int startLine, int count, int cols) const;
 
 
     // screen image ----------------
@@ -720,6 +728,7 @@ private:
     unsigned short lastDrawnChar;
 
     static Character defaultChar;
+    static Character nullChar;
 };
 
 }

--- a/lib/Screen.h
+++ b/lib/Screen.h
@@ -612,12 +612,14 @@ private:
     //count - the number of characters on the line to copy
     //decoder - a decoder which converts terminal characters (an Character array) into text
     //appendNewLine - if true a new line character (\n) is appended to the end of the line
+    //fullLine - if true the part of the line outside the screen is captured
     int  copyLineToStream(int line,
                           int start,
                           int count,
                           TerminalCharacterDecoder* decoder,
                           bool appendNewLine,
-                          bool preserveLineBreaks) const;
+                          bool preserveLineBreaks,
+                          bool fullLine) const;
 
     //fills a section of the screen image with the character 'c'
     //the parameters are specified as offsets from the start of the screen image.

--- a/lib/ScreenWindow.cpp
+++ b/lib/ScreenWindow.cpp
@@ -34,6 +34,9 @@ ScreenWindow::ScreenWindow(QObject* parent)
     , _windowBuffer(nullptr)
     , _windowBufferSize(0)
     , _bufferNeedsUpdate(true)
+    , _uncutBuffer(nullptr)
+    , _uncutBufferSize(0)
+    , _uncutColumns(0)
     , _windowLines(1)
     , _currentLine(0)
     , _trackOutput(true)
@@ -43,6 +46,7 @@ ScreenWindow::ScreenWindow(QObject* parent)
 ScreenWindow::~ScreenWindow()
 {
     delete[] _windowBuffer;
+    delete[] _uncutBuffer;
 }
 void ScreenWindow::setScreen(Screen* screen)
 {
@@ -54,6 +58,35 @@ void ScreenWindow::setScreen(Screen* screen)
 Screen* ScreenWindow::screen() const
 {
     return _screen;
+}
+
+Character* ScreenWindow::getUncutImage(int &uncutColumns)
+{
+    int cols = windowColumns();
+    int lines = windowLines();
+
+    _uncutColumns = _screen->getColumnCeil(currentLine(),endWindowLine());
+    if (_uncutColumns > cols)
+    {
+        int size = lines*_uncutColumns;
+        uncutColumns = _uncutColumns;
+        if (_uncutBufferSize != size)
+        {
+            delete[] _uncutBuffer;
+            _uncutBuffer = new Character[size];
+        }
+        _screen->getImage(_uncutBuffer, size, currentLine(), endWindowLine(), _uncutColumns);
+        // the filters don't need this but maybe enable for later use elsewhere
+//        fillUnusedArea(_uncutBuffer + _uncutBufferSize, _uncutColumns);
+        return _uncutBuffer;
+    }
+
+    _uncutColumns = 0;
+    _uncutBufferSize = 0;
+    delete[] _uncutBuffer;
+    _uncutBuffer = nullptr;
+    uncutColumns = cols;
+    return getImage();
 }
 
 Character* ScreenWindow::getImage()
@@ -77,21 +110,21 @@ Character* ScreenWindow::getImage()
     // this window may look beyond the end of the screen, in which
     // case there will be an unused area which needs to be filled
     // with blank characters
-    fillUnusedArea();
+    fillUnusedArea(_windowBuffer + _windowBufferSize, windowColumns());
 
     _bufferNeedsUpdate = false;
     return _windowBuffer;
 }
 
-void ScreenWindow::fillUnusedArea()
+void ScreenWindow::fillUnusedArea(Character *end, int cols)
 {
     int screenEndLine = _screen->getHistLines() + _screen->getLines() - 1;
     int windowEndLine = currentLine() + windowLines() - 1;
 
     int unusedLines = windowEndLine - screenEndLine;
-    int charsToFill = unusedLines * windowColumns();
+    int charsToFill = unusedLines * cols;
 
-    Screen::fillWithDefaultChar(_windowBuffer + _windowBufferSize - charsToFill,charsToFill);
+    Screen::fillWithDefaultChar(end - charsToFill, charsToFill);
 }
 
 // return the index of the line at the end of this window, or if this window

--- a/lib/ScreenWindow.h
+++ b/lib/ScreenWindow.h
@@ -83,6 +83,17 @@ public:
     Character* getImage();
 
     /**
+     * Returns the image of characters which are currently visible through this window
+     * onto the screen if the window had infinite width
+     *
+     * The @p uncutColumns parameter will be updated to report the actual width of the image
+     *
+     * The returned buffer is managed by the ScreenWindow instance and does not need to be
+     * deleted by the caller.
+     */
+    Character* getUncutImage(int &uncutColumns);
+
+    /**
      * Returns the line attributes associated with the lines of characters which
      * are currently visible through this window
      */
@@ -246,12 +257,15 @@ signals:
 
 private:
     int endWindowLine() const;
-    void fillUnusedArea();
+    void fillUnusedArea(Character *end, int cols);
 
     Screen* _screen; // see setScreen() , screen()
     Character* _windowBuffer;
     int _windowBufferSize;
     bool _bufferNeedsUpdate;
+    Character* _uncutBuffer;
+    int _uncutBufferSize;
+    int _uncutColumns;
 
     int  _windowLines;
     int  _currentLine; // see scrollTo() , currentLine()

--- a/lib/TerminalCharacterDecoder.cpp
+++ b/lib/TerminalCharacterDecoder.cpp
@@ -110,6 +110,11 @@ void PlainTextDecoder::decodeLine(const Character* const characters, int count, 
 
     for (int i = 0; i < outputCount;)
     {
+        if (characters[i] == '\0')
+        {   // ignore non-printable padding
+            ++i;
+            continue;
+        }
         if (characters[i].rendition & RE_EXTENDED_CHAR)
         {
             ushort extendedCharLength = 0;
@@ -185,6 +190,9 @@ void HTMLDecoder::decodeLine(const Character* const characters, int count, LineP
 
     for (int i=0;i<count;i++)
     {
+        if (characters[i] == '\0')
+            continue; // ignore non-printable padding
+
         //check if appearance of character is different from previous char
         if ( characters[i].rendition != _lastRendition  ||
              characters[i].foregroundColor != _lastForeColor  ||

--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -1120,10 +1120,9 @@ void TerminalDisplay::processFilters()
     // ScreenWindow emits a scrolled() signal - which will happen before
     // updateImage() is called on the display and therefore _image is
     // out of date at this point
-    _filterChain->setImage( _screenWindow->getImage(),
-                            _screenWindow->windowLines(),
-                            _screenWindow->windowColumns(),
-                            _screenWindow->getLineProperties() );
+    int fullCols;
+    Character *image = _screenWindow->getUncutImage(fullCols);
+    _filterChain->setImage( image, _screenWindow->windowLines(), fullCols, _screenWindow->getLineProperties() );
     _filterChain->process();
 
     QRegion postUpdateHotSpots = hotSpotRegion();


### PR DESCRIPTION
Fixes #576

Unfortunately the filters are exported API we cannot just change So instead of the sane approach to just filter on the screenLines and history lines we do the next best thing and special-case the situation where stuff is actually cut off screen (what is typically not the case)

---

Pending issue is that if you grow a window so the wrapped URL not longer touches the EOL it will only be partially filtered.
I'll open a bug to address the re-flow situation