### PR TITLE
Fix default keytab and add a "modern" one

### DIFF
--- a/lib/kb-layouts/modern.keytab
+++ b/lib/kb-layouts/modern.keytab
@@ -7,7 +7,7 @@
 #
 # --------------------------------------------------------------
 
-keyboard "Default (XFree 4)"
+keyboard "Modern (XFree 4)"
 
 # --------------------------------------------------------------
 #
@@ -32,14 +32,14 @@ key Return-Shift+NewLine : "\r\n"
 
 key Return+Shift         : "\EOM"
 
-# Backspace and Delete codes are preserving CTRL-H.
+# Match konsole/VTE and "XTerm.backarrowKeyIsErase:true" behaviour:
 #
-# Backspace without CTRL sends '^H'; this matches XTerm default behaviour
-# BS, hex \x08, \b
-key Backspace -Control : "\b"
+# Backspace without CTRL sends '^?'
+key Backspace -Control : "\x7f"
 
-# Match xterm behaviour: Backspace sends '^?' when Control is pressed
-key Backspace +Control : "\x7f"
+# Backspace sends '^H' when Control is pressed
+# BS, hex \x08, \b
+key Backspace +Control : "\b"
 
 # Arrow keys in VT52 mode
 # shift up/down are reserved for scrolling.


### PR DESCRIPTION
1. shift+lef/right are not hardcoded to any tab behavior qtermwidget doesn't do tabs and qterminal has alt+lef/right to switch between tiles by default, nothing hardcoded Also it doesn't really matter because the shortcut hides the input from the terminal. Otoh shift+left/right is a common selection mnemonic

2. The backspace situation is a historic mess, but it is what it is. xterm's manpage spends like 60 lines on the matter and while it is correct that the xterm default behavior is ^H/^? for /ctrl (claims to the contrary are false and likely informed by downstream patches) there are also numerous ways to configure that (backarrowKeyIsErase being the most abstract one) Several terminal clients make unconditional assumptions about it (try to enter "cat" and then use the backarrow key to make it type ^? instead of ^H) So to let end users out of this brain-wreck, add a "modern" keytab that emulates the inversed xterm behavior and allows future adjustments for popular non-standard scenarios.

---
fixes #235
Supersedes https://github.com/lxqt/qtermwidget/pull/547

Side-note: the macbook.keytab was at some point altered to pass on shift+left/right but also shift+up/down (which are indeed hardcoded to scrolling) and sets the backspace to \?, no setting for ctrl+backspace, the comments were however not adjusted and don't reflect that.

